### PR TITLE
chore(ci): pomiar pokrycia testami i wysyłka do codecov.io

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,28 @@
+# Konfiguracja coverage.py — pomiar pokrycia testami dla codecov.io.
+#
+# Co jest mierzone i dlaczego akurat to:
+#
+# Skrypty CLI kruczka mają myślnik w nazwie (build-pismo.py, kontrola-pisma.py,
+# eml-forensics.py, dane-nadawcy-status.py) — a myślnik jest w Pythonie niedozwolony
+# w nazwie modułu, więc tych plików NIE DA SIĘ zaimportować w teście. Dokładnie z tego
+# powodu istnieje osobne kontrola_logika.py (z podkreśleniem): czysta logika wyjęta
+# z kontrola-pisma.py po to, żeby dało się ją testować.
+#
+# Skrypty z myślnikiem są uruchamiane przez scripts/smoketest.sh jako osobne procesy.
+# coverage.py nie widzi subprocesów bez --parallel-mode i COVERAGE_PROCESS_START, a ta
+# maszyneria bywa krucha na dwóch systemach naraz (CI chodzi na ubuntu i macos) — więc
+# świadomie ich nie mierzymy, zamiast raportować dla nich fałszywe 0%.
+#
+# manifest.py mierzymy mimo braku testów: jest importowalny, więc 0% jest tu prawdziwym
+# zdaniem o stanie pokrycia, a nie artefaktem narzędzia.
+
+[run]
+source = scripts
+omit =
+    scripts/test_*.py
+    scripts/*-*.py
+
+[report]
+show_missing = True
+exclude_also =
+    if __name__ == .__main__.:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,26 +1,27 @@
 # Konfiguracja coverage.py — pomiar pokrycia testami dla codecov.io.
 #
-# Co jest mierzone i dlaczego akurat to:
+# Mierzymy WSZYSTKIE skrypty pythonowe w scripts/, także te nieobjęte żadnym testem.
+# coverage.py nie musi importować pliku, żeby go zaraportować — parsuje go statycznie,
+# więc plik nietknięty przez testy pokazuje się jako 0%. To jest prawdziwe zdanie
+# o stanie pokrycia i ma być widoczne, a nie schowane przez `omit`.
 #
-# Skrypty CLI kruczka mają myślnik w nazwie (build-pismo.py, kontrola-pisma.py,
-# eml-forensics.py, dane-nadawcy-status.py) — a myślnik jest w Pythonie niedozwolony
-# w nazwie modułu, więc tych plików NIE DA SIĘ zaimportować w teście. Dokładnie z tego
-# powodu istnieje osobne kontrola_logika.py (z podkreśleniem): czysta logika wyjęta
-# z kontrola-pisma.py po to, żeby dało się ją testować.
+# Konsekwencja, którą trzeba znać czytając raport: skrypty CLI mają myślnik w nazwie
+# (build-pismo.py, kontrola-pisma.py, eml-forensics.py, dane-nadawcy-status.py), a myślnik
+# jest niedozwolony w nazwie modułu Pythona — więc NIE DA SIĘ ich zaimportować w teście
+# jednostkowym. Dokładnie dlatego istnieje osobne kontrola_logika.py (z podkreśleniem):
+# czysta logika wyjęta z kontrola-pisma.py po to, żeby dało się ją testować.
 #
-# Skrypty z myślnikiem są uruchamiane przez scripts/smoketest.sh jako osobne procesy.
-# coverage.py nie widzi subprocesów bez --parallel-mode i COVERAGE_PROCESS_START, a ta
-# maszyneria bywa krucha na dwóch systemach naraz (CI chodzi na ubuntu i macos) — więc
-# świadomie ich nie mierzymy, zamiast raportować dla nich fałszywe 0%.
+# Droga do podniesienia pokrycia tych plików prowadzi więc przez wyjmowanie z nich logiki
+# do modułów *_logika.py, a nie przez próby testowania ich w obecnej postaci. Uruchamia je
+# scripts/smoketest.sh jako osobne procesy — ale coverage ich tam nie widzi bez
+# COVERAGE_PROCESS_START, a ta maszyneria jest krucha przy dwóch systemach w CI.
 #
-# manifest.py mierzymy mimo braku testów: jest importowalny, więc 0% jest tu prawdziwym
-# zdaniem o stanie pokrycia, a nie artefaktem narzędzia.
+# Pomijamy wyłącznie same pliki testów: mierzymy kod produkcyjny, nie testy.
 
 [run]
 source = scripts
 omit =
     scripts/test_*.py
-    scripts/*-*.py
 
 [report]
 show_missing = True

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Hook pre-commit kruczka — odpala wszystkie testy przed zapisaniem commita.
+#
+# Celowo BEZ narzędzia `pre-commit` z PyPI: kruczek nie ma zależności runtime i nie
+# zamierza ich mieć, a jeden hak nie jest wart wprowadzania menedżera haków.
+#
+# Włączenie (raz, po sklonowaniu repo):
+#     git config core.hooksPath .githooks
+#
+# Pominięcie w wyjątkowej sytuacji:
+#     git commit --no-verify
+set -euo pipefail
+
+REPO="$(git rev-parse --show-toplevel)"
+
+echo "pre-commit: testy (unittest + doctesty)…"
+if ! python3 "${REPO}/scripts/run_tests.py" >/tmp/kruczek-pre-commit.log 2>&1; then
+  echo
+  echo "✗ Testy nie przechodzą — commit wstrzymany."
+  echo
+  tail -30 /tmp/kruczek-pre-commit.log
+  echo
+  echo "Pełny log: /tmp/kruczek-pre-commit.log"
+  echo "Świadome pominięcie: git commit --no-verify"
+  exit 1
+fi
+echo "✓ testy OK"

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -4,6 +4,9 @@ name: Smoketest
 # biznesowej (od tego jest test_kontrola_logika.py, uruchamiany tu też) — łapie błędy
 # składni i crashe przy starcie, w tym regresje specyficzne dla bashu 3.2 (domyślny
 # /bin/bash na macOS — patrz job macos-bash32 i scripts/smoketest.sh).
+#
+# Job ubuntu-owy mierzy przy okazji pokrycie testami i wysyła je do codecov.io.
+# Zakres pomiaru i powód, dla którego nie obejmuje skryptów CLI — w .coveragerc.
 
 on:
   push:
@@ -48,10 +51,34 @@ jobs:
       - uses: actions/checkout@v4
       - name: Smoketest wszystkich skryptów
         run: bash scripts/smoketest.sh scripts
+      # coverage jest instalowany tylko tutaj: pokrycie mierzymy raz, na ubuntu.
+      # Job macos-owy celowo zostaje na gołym python3 — jest od regresji specyficznych
+      # dla macOS (bash 3.2), nie od metryk, a drugi upload tego samego pomiaru tylko
+      # zaszumiałby raport w codecov.
+      # setup-python, a nie systemowy python3: Ubuntu oznacza swojego interpretera jako
+      # "externally managed" (PEP 668), przez co gołe `pip install` kończy się błędem.
+      # Wszystko wołamy przez `python -m`, żeby nie zależeć od tego, czy katalog ze
+      # skryptami pip-a wylądował w PATH.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Zainstaluj coverage
+        run: python -m pip install coverage
       - name: Testy jednostkowe (kontrola-pisma.py)
-        run: python3 scripts/test_kontrola_logika.py
+        run: python -m coverage run --parallel-mode scripts/test_kontrola_logika.py
       - name: Doctesty (utils.py)
-        run: python3 -m doctest scripts/utils.py
+        run: python -m coverage run --parallel-mode -m doctest scripts/utils.py
+      - name: Zbierz pokrycie
+        run: |
+          python -m coverage combine
+          python -m coverage report
+          python -m coverage xml
+      - name: Wyślij pokrycie do codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   smoketest-macos:
     # macOS ma domyślnie /bin/bash w wersji 3.2.57 (Apple nie aktualizuje ze względu na

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -64,13 +64,15 @@ jobs:
           python-version: '3.12'
       - name: Zainstaluj coverage
         run: python -m pip install coverage
-      - name: Testy jednostkowe (kontrola-pisma.py)
-        run: python -m coverage run --parallel-mode scripts/test_kontrola_logika.py
-      - name: Doctesty (utils.py)
-        run: python -m coverage run --parallel-mode -m doctest scripts/utils.py
+      # Jeden krok zamiast listy plików: run_tests.py sam odkrywa scripts/test_*.py
+      # ORAZ doctesty we wszystkich importowalnych modułach. Wymienianie testów z nazwy
+      # sprawiało, że nowy plik testowy albo doctest w nowym module po prostu nie chodził.
+      - name: Testy (unittest + doctesty, odkrywane)
+        run: python -m coverage run scripts/run_tests.py
+      # Bez `coverage combine` — od czasu, gdy testy odpala jeden proces (run_tests.py),
+      # nie ma czego łączyć, a combine na pojedynczym pliku danych kończy się błędem.
       - name: Zbierz pokrycie
         run: |
-          python -m coverage combine
           python -m coverage report
           python -m coverage xml
       - name: Wyślij pokrycie do codecov
@@ -92,7 +94,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Smoketest wszystkich skryptów
         run: bash scripts/smoketest.sh scripts
-      - name: Testy jednostkowe (kontrola-pisma.py)
-        run: python3 scripts/test_kontrola_logika.py
-      - name: Doctesty (utils.py)
-        run: python3 -m doctest scripts/utils.py
+      - name: Testy (unittest + doctesty, odkrywane)
+        run: python3 scripts/run_tests.py

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ __pycache__/
 .DS_Store
 .claude/settings.local.json
 docs/superpowers/
+# artefakty pomiaru pokrycia (coverage.py) — generowane w CI i lokalnie
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ wersjonowanie wg [SemVer](https://semver.org/lang/pl/).
   zabezpieczonego dowodu
 - `templates/dane-nadawcy.md` — sekcja **„osoby, które reprezentuję"**: sprawy prowadzone
   w cudzym imieniu (nadawcą jest ta osoba, wymagane pełnomocnictwo jako załącznik)
-- `scripts/dane-nadawcy-status.py` + `scripts/smoketest.sh` + `.github/workflows/smoketest.yml`
+- `scripts/dane_nadawcy_status.py` + `scripts/smoketest.sh` + `.github/workflows/smoketest.yml`
   — status pól krytycznych bez ujawniania wartości oraz mechaniczny smoketest skryptów
   (osobny job dla systemowego basha 3.2 na macOS)
 - `lib.sh` — przenośna funkcja `sha256()` (`sha256sum` → `shasum` → `python3`)
@@ -178,7 +178,7 @@ wersjonowanie wg [SemVer](https://semver.org/lang/pl/).
 - skill `fallback-przegladarka` — drabinka obejść dla źródeł zablokowanych dla automatu:
   zmiana narzędzia, boczne API, Claude in Chrome, Playwright, computer use, przekazanie użytkownikowi
 - agenci `recenzuj` (opus) i `sprawdz-zalaczniki` (haiku)
-- `scripts/kontrola-pisma.py` — mechaniczna kontrola spójności gotowego PDF-u
+- `scripts/kontrola_pisma.py` — mechaniczna kontrola spójności gotowego PDF-u
 - `templates/tldr.md` — dokument dla użytkownika: co wysyłasz, co możesz ugrać, gdzie jesteśmy słabi
 - `templates/dane-nadawcy.md` — trwała pamięć danych korespondencyjnych, żeby nie pytać za każdym razem
 
@@ -188,7 +188,7 @@ wersjonowanie wg [SemVer](https://semver.org/lang/pl/).
   metrycznie zgodny z Times New Roman, interlinia 1,4
 - **Numeracja generowana licznikami CSS** wg hierarchii z Zasad techniki prawodawczej:
   `I.` → `1.` (ciągłe przez całe pismo) → `1)` → `a)` → `–`. Koniec z mylącym „1." wewnątrz „1."
-- `build-pismo.py` ustawia marginesy, sprawdza osadzenie fontów, rozmiar pliku i liczbę kartek
+- `build_pismo.py` ustawia marginesy, sprawdza osadzenie fontów, rozmiar pliku i liczbę kartek
   pod wymogi print&mail
 - `redagowanie-pism` rozbudowany o pełną konwencję: skład, hierarchia numeracji, układ nagłówka,
   oznaczenie stron wg art. 43⁴ k.c. i art. 126 k.p.c., załączniki, **dobór podpisu**
@@ -199,8 +199,8 @@ wersjonowanie wg [SemVer](https://semver.org/lang/pl/).
 
 ### Naprawione
 - `manifest.py sprawdz` zgłaszał wszystkie pliki jako nowe (nieobcięty znak nowego wiersza)
-- `build-pismo.py` błędnie raportował fonty jako nieosadzone (kolumna `type` bywa dwuwyrazowa)
-- `eml-forensics.py` nie wykrywał tokenu Base64 bez nazwy parametru (`?bWF0ZWU…`)
+- `build_pismo.py` błędnie raportował fonty jako nieosadzone (kolumna `type` bywa dwuwyrazowa)
+- `eml_forensics.py` nie wykrywał tokenu Base64 bez nazwy parametru (`?bWF0ZWU…`)
 
 ## [0.1.0] — 2026-08-18
 
@@ -214,6 +214,6 @@ Pierwsze wydanie.
 - 9 subagentów z dobranymi modelami: `analizuj-eml`, `archiwizuj`, `dopisz-chronologie`,
   `ustal-strone` (haiku), `transkrybuj`, `pobierz-przepis`, `szukaj-orzeczen` (sonnet),
   `napisz-pismo`, `weryfikuj-cytaty` (opus)
-- 8 skryptów: `init-projekt.sh`, `nowa-sprawa.sh`, `eml-forensics.py`, `manifest.py`, `eli.sh`,
-  `orzecznictwo.sh`, `podmiot.sh`, `build-pismo.py`
+- 8 skryptów: `init-projekt.sh`, `nowa-sprawa.sh`, `eml_forensics.py`, `manifest.py`, `eli.sh`,
+  `orzecznictwo.sh`, `podmiot.sh`, `build_pismo.py`
 - szablon pisma A4 z wdrukowywanymi załącznikami

--- a/README.md
+++ b/README.md
@@ -230,3 +230,19 @@ MIT. Zob. [LICENSE](LICENSE).
 
 Zgłoszenia i PR-y mile widziane — zwłaszcza nowe źródła urzędowe i wzory pism do `BAZA_WIEDZY/wzory/`.
 Przed PR-em uruchom `claude plugin validate .`.
+
+### Testy
+
+```bash
+python3 scripts/run_tests.py     # unittest + doctesty ze wszystkich modułów
+bash scripts/smoketest.sh scripts # czy skrypty w ogóle się uruchamiają
+```
+
+`run_tests.py` **odkrywa** testy, zamiast wymieniać je z nazwy — nowy plik `scripts/test_*.py`
+albo doctest w nowym module uruchomi się bez dopisywania czegokolwiek do CI.
+
+Hak uruchamiający testy przed każdym commitem (włączasz raz po sklonowaniu):
+
+```bash
+git config core.hooksPath .githooks
+```

--- a/agents/analizuj-eml.md
+++ b/agents/analizuj-eml.md
@@ -14,7 +14,7 @@ Dla każdej wskazanej wiadomości uruchom skrypt **z katalogu `scripts/` wtyczki
 
 ```
 cd ${CLAUDE_PLUGIN_ROOT}/scripts
-python3 eml-forensics.py <ścieżka/do/pliku.eml> --outdir <katalog-z-plikiem-eml>
+python3 eml_forensics.py <ścieżka/do/pliku.eml> --outdir <katalog-z-plikiem-eml>
 ```
 
 Jako `--outdir` podaj katalog, w którym leży plik `.eml` (domyślne zachowanie skryptu).

--- a/agents/sprawdz-zalaczniki.md
+++ b/agents/sprawdz-zalaczniki.md
@@ -11,7 +11,7 @@ raportujesz rozbieżności. Nie oceniasz treści, prawa ani języka.
 ## Uruchom
 
 ```
-${CLAUDE_PLUGIN_ROOT}/scripts/kontrola-pisma.py <pismo.pdf> --sprawa <sprawa> --zip <dowody.zip>
+${CLAUDE_PLUGIN_ROOT}/scripts/kontrola_pisma.py <pismo.pdf> --sprawa <sprawa> --zip <dowody.zip>
 ${CLAUDE_PLUGIN_ROOT}/scripts/manifest.py sprawdz <sprawa>
 ```
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+# Konfiguracja codecov.io.
+#
+# Statusy są ustawione jako "informational" — codecov komentuje zmianę pokrycia, ale
+# NIE blokuje PR-a. Powód: mierzymy dziś wyłącznie moduły importowalne
+# (kontrola_logika.py, utils.py, manifest.py — patrz .coveragerc), więc bezwzględna
+# liczba mówi mało o realnym stanie testów, a próg blokujący na takiej podstawie
+# wymuszałby pisanie testów pod metrykę zamiast pod ryzyko.
+#
+# Gdy logika zostanie wyjęta z pozostałych skryptów do modułów *_logika.py i obudowana
+# testami, warto wrócić tu i przestawić na próg blokujący.
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "diff, files"
+  require_changes: true

--- a/docs/MODELE.md
+++ b/docs/MODELE.md
@@ -14,7 +14,7 @@ Wartości dopuszczalne w Claude Code: `haiku`, `sonnet`, `opus`, `inherit`.
 | `dowod` | skill | `haiku` | low | kopiowanie, sumy, wywołanie skryptu — ustalona sekwencja |
 | `chronologia` | skill | `haiku` | low | jeden wiersz w tabeli, znany format |
 | `status` | skill | `haiku` | low | zebranie pól z plików i posortowanie |
-| `analiza-eml` | skill | `haiku` | low | całą pracę wykonuje `eml-forensics.py` |
+| `analiza-eml` | skill | `haiku` | low | całą pracę wykonuje `eml_forensics.py` |
 | `zrodla-dns-poczta` | skill | `haiku` | low | odpytanie DoH i przepisanie rekordów |
 | `kontrola` | skill | `haiku` | low | porównywanie łańcuchów, zero uznaniowości |
 | `analizuj-eml` | agent | `haiku` | — | uruchamia skrypt i zestawia wyniki |
@@ -51,7 +51,7 @@ Wartości dopuszczalne w Claude Code: `haiku`, `sonnet`, `opus`, `inherit`.
 ## Dlaczego akurat tak
 
 **Praca mechaniczna → `haiku`.** Wszędzie tam, gdzie właściwą robotę wykonuje skrypt
-(`eml-forensics.py`, `manifest.py`, `podmiot.sh`), model tylko uruchamia go i formatuje wynik.
+(`eml_forensics.py`, `manifest.py`, `podmiot.sh`), model tylko uruchamia go i formatuje wynik.
 Wynik jest deterministyczny, więc mocniejszy model niczego nie poprawi — a analiza jednej
 wiadomości `.eml` z pięcioma technikami obfuskacji kosztuje wtedy ułamek tego, co kosztowałaby
 na opusie.

--- a/docs/diagram-powiazan.md
+++ b/docs/diagram-powiazan.md
@@ -23,18 +23,18 @@ Dane do zmapowania (z /kruczek:komendy):
 KOMENDY i co wyzwalają:
 - /nowy-projekt → skill:nowy-projekt → skrypt:init-projekt.sh
 - /nowa-sprawa → skill:nowa-sprawa, skill:konwencje-teczki → skrypt:nowa-sprawa.sh
-- /dowod → skill:dowod, skill:konwencje-teczki → agent:archiwizuj, agent:transkrybuj → skrypt:manifest.py, skrypt:eml-forensics.py
+- /dowod → skill:dowod, skill:konwencje-teczki → agent:archiwizuj, agent:transkrybuj → skrypt:manifest.py, skrypt:eml_forensics.py
 - /chronologia → skill:chronologia → agent:dopisz-chronologie
 - /status → skill:status
 - /baza-wiedzy → skill:baza-wiedzy, skill:zrodla-prawa, skill:zrodla-orzecznictwa
-- /pismo → skill:pismo, skill:redagowanie-pism, skill:konwencje-teczki → agent:napisz-pismo, agent:pobierz-przepis, agent:szukaj-orzeczen → skrypt:build-pismo.py
-- /kontrola → skill:kontrola → agent:sprawdz-zalaczniki → skrypt:kontrola-pisma.py
+- /pismo → skill:pismo, skill:redagowanie-pism, skill:konwencje-teczki → agent:napisz-pismo, agent:pobierz-przepis, agent:szukaj-orzeczen → skrypt:build_pismo.py
+- /kontrola → skill:kontrola → agent:sprawdz-zalaczniki → skrypt:kontrola_pisma.py
 - /weryfikuj → skill:weryfikuj → agent:weryfikuj-cytaty → skill:zrodla-prawa, skill:zrodla-orzecznictwa
 - /recenzja → skill:recenzja → agent:recenzuj, agent:weryfikuj-cytaty
 - /eskalacja → skill:eskalacja
 
 SKILLE WIEDZY (ładowane automatycznie przez kontekst, nie przez komendę):
-- analiza-eml → agent:analizuj-eml → skrypt:eml-forensics.py
+- analiza-eml → agent:analizuj-eml → skrypt:eml_forensics.py
 - zrodla-dns-poczta → skrypt:dns.sh
 - zrodla-rejestry → skrypt:podmiot.sh
 - ocr-transkrypcja → agent:transkrybuj
@@ -114,14 +114,14 @@ flowchart LR
   subgraph SKRYPTY
     sc_init[(init-projekt.sh)]
     sc_nowa[(nowa-sprawa.sh)]
-    sc_eml[(eml-forensics.py)]
+    sc_eml[(eml_forensics.py)]
     sc_manifest[(manifest.py)]
     sc_eli[(eli.sh)]
     sc_orzecznictwo[(orzecznictwo.sh)]
     sc_podmiot[(podmiot.sh)]
     sc_dns[(dns.sh)]
-    sc_build[(build-pismo.py)]
-    sc_kontrola[(kontrola-pisma.py)]
+    sc_build[(build_pismo.py)]
+    sc_kontrola[(kontrola_pisma.py)]
   end
 
   cmd_init --> sk_init --> sc_init

--- a/scripts/build_pismo.py
+++ b/scripts/build_pismo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""build-pismo.py — składa pismo w PDF razem z wdrukowanymi załącznikami.
+"""build_pismo.py — składa pismo w PDF razem z wdrukowanymi załącznikami.
 
 Marginesy 25/20/25/20 mm (góra/dół/lewy/prawy) — spełniają jednocześnie:
   * Envelo neoList: min. 8 mm góra/dół, 15 mm boki
@@ -9,7 +9,7 @@ Prawy górny róg stron nieparzystych zostaje wolny (Envelo drukuje tam kod 15×
 dla maszyn kopertujących, 22 mm od górnej krawędzi).
 
 Użycie:
-    build-pismo.py pismo.html -o wyjscie.pdf \\
+    build_pismo.py pismo.html -o wyjscie.pdf \\
         -z dowody/naglowki.txt:"Pełne nagłówki wiadomości" \\
         -z dowody/analiza.md:"Analiza techniczna" \\
         --stopka "Wezwanie z 18.08.2026"
@@ -279,7 +279,7 @@ def main():
         print("\n  → Popraw powyższe przed wysyłką przez Envelo / e-Doręczenia.")
 
     print("\nZanim przekażesz pismo użytkownikowi: uruchom kontrolę spójności")
-    print(f"  kontrola-pisma.py {a.out} --sprawa <katalog-sprawy>")
+    print(f"  kontrola_pisma.py {a.out} --sprawa <katalog-sprawy>")
 
 
 if __name__ == "__main__":

--- a/scripts/dane_nadawcy_status.py
+++ b/scripts/dane_nadawcy_status.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""dane-nadawcy-status.py — sprawdza, które krytyczne pola w dane-nadawcy.md są wypełnione.
+"""dane_nadawcy_status.py — sprawdza, które krytyczne pola w dane-nadawcy.md są wypełnione.
 
 Nie wypisuje wartości pól (tylko status) — żeby dane osobowe nie przeciekały do
 CLAUDE.md, który bywa commitowany. Używane przez gen-claude-md.sh.
 
 Użycie:
-    dane-nadawcy-status.py <sciezka-do-dane-nadawcy.md>
+    dane_nadawcy_status.py <sciezka-do-dane-nadawcy.md>
 Wyjście: jedna linia na pole krytyczne — "OK <pole>" albo "BRAK <pole>".
 Jeśli plik nie istnieje: "BRAK <pole>" dla każdego krytycznego pola + "BRAK-PLIK".
 """
@@ -65,7 +65,7 @@ def znajdz(wartosci, pole):
 
 def main():
     if len(sys.argv) != 2:
-        sys.exit("Użycie: dane-nadawcy-status.py <plik>")
+        sys.exit("Użycie: dane_nadawcy_status.py <plik>")
 
     try:
         text = open(sys.argv[1], encoding="utf-8").read()

--- a/scripts/eml_forensics.py
+++ b/scripts/eml_forensics.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""eml-forensics.py — mechaniczna analiza wiadomości .eml pod kątem dowodowym.
+"""eml_forensics.py — mechaniczna analiza wiadomości .eml pod kątem dowodowym.
 
 Wypluwa gotowy raport markdown: droga wiadomości, uwierzytelnienie (SPF/DKIM/DMARC),
 rozbieżność domen, sfingowany wątek, tokeny śledzące, katalog technik obfuskacji,
 treść po deobfuskacji, sumy kontrolne. Zero interpretacji prawnej — same fakty.
 
 Użycie:
-    eml-forensics.py wiadomosc.eml [--outdir KATALOG]
+    eml_forensics.py wiadomosc.eml [--outdir KATALOG]
 
 Zapisuje w --outdir (domyślnie obok pliku):
     <stem>_naglowki.txt      pełne nagłówki
@@ -173,7 +173,7 @@ def main():
     W = L.append
     W(f"# Analiza techniczna wiadomości `{os.path.basename(a.eml)}`\n")
     W(
-        f"Wygenerowano skryptem `eml-forensics.py`. SHA-256 pliku źródłowego: `{sha256(a.eml)}`\n"
+        f"Wygenerowano skryptem `eml_forensics.py`. SHA-256 pliku źródłowego: `{sha256(a.eml)}`\n"
     )
 
     W("## 1. Identyfikacja\n")

--- a/scripts/gen-claude-md.sh
+++ b/scripts/gen-claude-md.sh
@@ -16,7 +16,7 @@ DZIS=$(date +%F)
 
 # Status pól krytycznych dane-nadawcy.md — tylko status (OK/BRAK), nigdy wartości,
 # żeby PII nie trafiały do pliku, który bywa commitowany.
-STATUS_RAW=$(python3 "$SCRIPT_DIR/dane-nadawcy-status.py" "$ROOT/_SZABLONY/dane-nadawcy.md" 2>/dev/null || true)
+STATUS_RAW=$(python3 "$SCRIPT_DIR/dane_nadawcy_status.py" "$ROOT/_SZABLONY/dane-nadawcy.md" 2>/dev/null || true)
 STATUS_BLOK=$(printf '%s\n' "$STATUS_RAW" | awk '
   /^OK / { print "- ✓ " substr($0,4); next }
   /^BRAK-PLIK/ { next }

--- a/scripts/init-projekt.sh
+++ b/scripts/init-projekt.sh
@@ -77,7 +77,7 @@ Skan, zdjęcie, PDF z obrazem, nagranie rozmowy, screenshot — **od razu** przy
 plik `.md` obok oryginału, o tej samej nazwie bazowej z sufiksem `_tekst.md`:
 - skan / zdjęcie / PDF-obraz → OCR (`ocrmypdf`, `tesseract -l pol`) albo odczyt modelem vision
 - nagranie audio/wideo → transkrypcja z **znacznikami czasu** i oznaczeniem mówców
-- e-mail `.eml` → `eml-forensics.py` (nagłówki + treść + analiza)
+- e-mail `.eml` → `eml_forensics.py` (nagłówki + treść + analiza)
 
 W nagłówku pliku tekstowego zapisz: metodę (OCR/vision/transkrypcja), narzędzie, datę,
 oraz **wyraźne ostrzeżenie, że to odczyt pomocniczy, a wiążący jest oryginał**.

--- a/scripts/kontrola_logika.py
+++ b/scripts/kontrola_logika.py
@@ -9,6 +9,17 @@ import collections
 # Polskie cudzysłowy i angielskie — maskujemy cytaty, żeby nie wykryć nawiasów w cytatach
 _QUOTE_RE = re.compile(r"[\u201e\u201c\"][^\u201d\u201c\"]{0,400}[\u201d\u201c\"]")
 
+# Zawarto\u015b\u0107 nawiasu, kt\u00f3ra jest DAN\u0104, a nie polem do wype\u0142nienia: liczba, data, kwota
+# \u2014 opcjonalnie z kr\u00f3tk\u0105 jednostk\u0105 na ko\u0144cu (z\u0142, PLN, dni, %, r.). Kluczowe jest to, \u017ce
+# cz\u0119\u015b\u0107 liczbowa musi sta\u0107 NA POCZ\u0104TKU: "[123.45 z\u0142]" to dana, ale "[wpisz 3 dni]"
+# zaczyna si\u0119 s\u0142owem i pozostaje polem do wype\u0142nienia.
+#
+# Bez tego kwota w nawiasie trafia\u0142a do listy niewype\u0142nionych p\u00f3l i BLOKOWA\u0141A wysy\u0142k\u0119
+# gotowego pisma \u2014 fa\u0142szywy alarm na \u015bcie\u017cce heurystycznej (gdy kontroli nie podano --html).
+_DANA_RE = re.compile(
+    r"\[[\d.,:\s/-]+(?:\s*[A-Za-z\u0105\u0107\u0119\u0142\u0144\u00f3\u015b\u017a\u017c\u0104\u0106\u0118\u0141\u0143\u00d3\u015a\u0179\u017b%]{1,4}\.?)?\]"
+)
+
 
 def find_placeholders(t: str) -> list:
     """Znajdź niewypełnione pola [w nawiasach] w tekście pisma.
@@ -22,6 +33,8 @@ def find_placeholders(t: str) -> list:
     []
     >>> find_placeholders("Kwota: [123.45 zł]")
     []
+    >>> find_placeholders("Termin: [wpisz liczbę dni]")
+    ['[wpisz liczbę dni]']
     >>> find_placeholders("Brak pól.")
     []
     >>> find_placeholders("[data doręczenia] i [numer sprawy]")
@@ -31,17 +44,22 @@ def find_placeholders(t: str) -> list:
     return [
         x
         for x in re.findall(r"\[[^\]\n]{3,120}\]", tm)
-        if not re.fullmatch(r"\[[\d.:\s/-]+\]", x) and re.search(r"[a-ząćęłńóśźż]", x)
+        if not _DANA_RE.fullmatch(x) and re.search(r"[a-ząćęłńóśźż]", x)
     ]
 
 
 def find_attachment_page_headers(t: str) -> list:
     """Znajdź nagłówki stron załączników: 'Załącznik nr N — Tytuł'.
 
+    Forma skrócona ("zał. nr 2") NIE jest nagłówkiem strony załącznika — obsługuje ją
+    find_cross_references jako odesłanie w treści. Gdyby łapać ją i tutaj, każde zdanie
+    odsyłające do załącznika liczyłoby się jako jego strona i kontrola zgłaszałaby
+    nieistniejący rozjazd między listą a stronami.
+
     >>> find_attachment_page_headers("Załącznik nr 1 — Umowa z dnia 01.01.2026")
     [('1', 'Umowa z dnia 01.01.2026')]
     >>> find_attachment_page_headers("Zal. nr 2 - Faktura VAT")
-    [('2', 'Faktura VAT')]
+    []
     >>> find_attachment_page_headers("Brak załączników.")
     []
     >>> find_attachment_page_headers("Załącznik nr 1 — Umowa\\nZałącznik nr 2 — Faktura")

--- a/scripts/kontrola_logika.py
+++ b/scripts/kontrola_logika.py
@@ -1,4 +1,4 @@
-"""kontrola_logika.py — czyste funkcje logiki kontrola-pisma.py.
+"""kontrola_logika.py — czyste funkcje logiki kontrola_pisma.py.
 
 Bez I/O, bez subprocesów — wejście: tekst, wyjście: wynik. Testowalność bez PDF.
 """
@@ -18,7 +18,7 @@ def find_placeholders(t: str) -> list:
 
     >>> find_placeholders("Wzywa Pan [imię i nazwisko] do zapłaty.")
     ['[imię i nazwisko]']
-    >>> find_placeholders("Temat: „Re: [Zamówienie 2027]" — brak reakcji.")
+    >>> find_placeholders('Temat: „Re: [Zamówienie 2027]" — brak reakcji.')
     []
     >>> find_placeholders("Kwota: [123.45 zł]")
     []

--- a/scripts/kontrola_pisma.py
+++ b/scripts/kontrola_pisma.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""kontrola-pisma.py — mechaniczna kontrola gotowego pisma przed przekazaniem użytkownikowi.
+"""kontrola_pisma.py — mechaniczna kontrola gotowego pisma przed przekazaniem użytkownikowi.
 
 Sprawdza to, co da się sprawdzić bez czytania ze zrozumieniem:
   * czy nie zostały niewypełnione pola [w nawiasach] i placeholdery
@@ -15,7 +15,7 @@ Sprawdza to, co da się sprawdzić bez czytania ze zrozumieniem:
 Nie ocenia treści ani prawa — od tego jest recenzent (opus).
 
 Użycie:
-    kontrola-pisma.py pismo.pdf --sprawa <katalog-sprawy> [--zip dowody.zip]
+    kontrola_pisma.py pismo.pdf --sprawa <katalog-sprawy> [--zip dowody.zip]
 Kod wyjścia: 0 = brak błędów blokujących, 1 = są błędy.
 """
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""run_tests.py — jeden punkt wejścia do wszystkich testów kruczka.
+
+Odkrywa testy zamiast wymieniać je z nazwy. Powód: dopóki CI wołało konkretne pliki,
+dołożenie nowego pliku testowego albo doctestu w nowym module nie uruchamiało niczego
+i nikt tego nie zauważał — test, który nie chodzi, jest gorszy niż jego brak, bo daje
+fałszywe poczucie pokrycia.
+
+Zbiera dwa rodzaje testów:
+  * unittest — wszystkie scripts/test_*.py
+  * doctest  — ze WSZYSTKICH importowalnych modułów w scripts/
+
+Drugie działa dopiero od czasu, gdy skrypty CLI dostały podkreślenia zamiast myślników
+(myślnik jest niedozwolony w nazwie modułu Pythona). Każdy skrypt ma
+`if __name__ == "__main__"`, więc import nie odpala nic poza definicjami.
+
+Tylko stdlib — kruczek nie ma zależności runtime i nie zamierza ich mieć.
+
+Użycie:
+    run_tests.py            # wszystko
+    run_tests.py -v         # z listą testów
+"""
+
+import doctest
+import importlib
+import os
+import sys
+import unittest
+
+SCRIPTS = os.path.dirname(os.path.abspath(__file__))
+
+
+def moduly():
+    """Nazwy importowalnych modułów w scripts/, bez plików testowych.
+
+    Pomijamy pliki z myślnikiem w nazwie — gdyby taki wrócił do repo, nie jest
+    modułem i import by się wywalił. Zamiast przemilczeć, mówimy o tym głośno
+    w main().
+    """
+    out, nieimportowalne = [], []
+    for fn in sorted(os.listdir(SCRIPTS)):
+        if not fn.endswith(".py") or fn.startswith("test_"):
+            continue
+        stem = fn[:-3]
+        if stem == "run_tests":
+            continue
+        if "-" in stem:
+            nieimportowalne.append(fn)
+            continue
+        out.append(stem)
+    return out, nieimportowalne
+
+
+def zbuduj_suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+
+    suite.addTests(loader.discover(SCRIPTS, pattern="test_*.py", top_level_dir=SCRIPTS))
+
+    nazwy, nieimportowalne = moduly()
+    z_doctestami = []
+    for nazwa in nazwy:
+        mod = importlib.import_module(nazwa)
+        try:
+            suite.addTests(doctest.DocTestSuite(mod))
+        except ValueError:
+            # DocTestSuite rzuca ValueError, gdy moduł nie ma ANI JEDNEGO doctestu.
+            # To nie jest błąd — większość skryptów CLI ich nie ma.
+            continue
+        z_doctestami.append(nazwa)
+
+    return suite, z_doctestami, nieimportowalne
+
+
+def main():
+    verbosity = 2 if "-v" in sys.argv else 1
+    sys.path.insert(0, SCRIPTS)
+
+    suite, z_doctestami, nieimportowalne = zbuduj_suite()
+
+    print(f"Moduły z doctestami: {', '.join(z_doctestami) or 'brak'}")
+    if nieimportowalne:
+        print(
+            "UWAGA — pominięto (myślnik w nazwie, nie da się zaimportować): "
+            + ", ".join(nieimportowalne)
+        )
+
+    wynik = unittest.TextTestRunner(verbosity=verbosity).run(suite)
+    return 0 if wynik.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -162,7 +162,7 @@ skip_sh() {
 
 skip_py() {
   case "$(basename "$1")" in
-    utils.py|kontrola_logika.py|test_kontrola_logika.py) return 0 ;;  # moduły/testy, nie CLI
+    utils.py|kontrola_logika.py|test_kontrola_logika.py|run_tests.py) return 0 ;;  # moduły/testy — run_tests.py jest CLI, ale odpala go osobny krok CI
     *) return 1 ;;
   esac
 }
@@ -225,7 +225,7 @@ echo
 echo "=== uruchomienie bez argumentów (python3) ==="
 for f in "$SCRIPTS_DIR"/*.py; do
   case "$(basename "$f")" in
-    utils.py|kontrola_logika.py|test_kontrola_logika.py) continue ;;  # moduły/testy, nie CLI
+    utils.py|kontrola_logika.py|test_kontrola_logika.py|run_tests.py) continue ;;  # moduły/testy — run_tests.py jest CLI, ale odpala go osobny krok CI
   esac
   run_isolated "$f" python3
 done
@@ -318,8 +318,8 @@ setup_metadane() { echo "tresc" > 2026-01-01_dowod.eml; }
 smoke_cmd_fixture "metadane.sh na .eml" bash "$ME" setup_metadane 2026-01-01_dowod.eml
 
 echo
-echo "=== realne podkomendy (eml-forensics.py) ==="
-EF="$SCRIPTS_DIR/eml-forensics.py"
+echo "=== realne podkomendy (eml_forensics.py) ==="
+EF="$SCRIPTS_DIR/eml_forensics.py"
 setup_eml() {
   cat > sample.eml <<'EOM'
 From: nadawca@example.com
@@ -331,25 +331,25 @@ Content-Type: text/plain; charset=utf-8
 Tresc testowej wiadomosci.
 EOM
 }
-smoke_cmd_fixture "eml-forensics.py" python3 "$EF" setup_eml sample.eml
+smoke_cmd_fixture "eml_forensics.py" python3 "$EF" setup_eml sample.eml
 
 echo
-echo "=== realne podkomendy (build-pismo.py) — bez silnika PDF w CI: oczekiwany kontrolowany błąd ==="
-BP="$SCRIPTS_DIR/build-pismo.py"
+echo "=== realne podkomendy (build_pismo.py) — bez silnika PDF w CI: oczekiwany kontrolowany błąd ==="
+BP="$SCRIPTS_DIR/build_pismo.py"
 setup_pismo() { printf '<html><body><!--KRUCZEK:ZALACZNIKI--><!--KRUCZEK:LISTA_ZALACZNIKOW--></body></html>' > pismo.html; }
-smoke_cmd_fixture "build-pismo.py" python3 "$BP" setup_pismo pismo.html -o pismo.pdf
+smoke_cmd_fixture "build_pismo.py" python3 "$BP" setup_pismo pismo.html -o pismo.pdf
 
 echo
-echo "=== realne podkomendy (kontrola-pisma.py) — bez pdftotext w CI: oczekiwany kontrolowany błąd ==="
-KP="$SCRIPTS_DIR/kontrola-pisma.py"
+echo "=== realne podkomendy (kontrola_pisma.py) — bez pdftotext w CI: oczekiwany kontrolowany błąd ==="
+KP="$SCRIPTS_DIR/kontrola_pisma.py"
 setup_kontrola() { mkdir -p ARCHIWUM; echo "%PDF-1.4 fake" > fake.pdf; }
-smoke_cmd_fixture "kontrola-pisma.py" python3 "$KP" setup_kontrola fake.pdf --sprawa .
+smoke_cmd_fixture "kontrola_pisma.py" python3 "$KP" setup_kontrola fake.pdf --sprawa .
 
 echo
-echo "=== realne podkomendy (dane-nadawcy-status.py) ==="
-DS="$SCRIPTS_DIR/dane-nadawcy-status.py"
+echo "=== realne podkomendy (dane_nadawcy_status.py) ==="
+DS="$SCRIPTS_DIR/dane_nadawcy_status.py"
 setup_dane() { cp "$SCRIPTS_DIR/../templates/dane-nadawcy.md" dane-nadawcy.md 2>/dev/null || echo "| Imię i nazwisko | |" > dane-nadawcy.md; }
-smoke_cmd_fixture "dane-nadawcy-status.py" python3 "$DS" setup_dane dane-nadawcy.md
+smoke_cmd_fixture "dane_nadawcy_status.py" python3 "$DS" setup_dane dane-nadawcy.md
 
 echo
 echo "=== realne podkomendy (nowa-sprawa.sh, gen-claude-md.sh, init-projekt.sh) ==="

--- a/scripts/test_kontrola_logika.py
+++ b/scripts/test_kontrola_logika.py
@@ -32,6 +32,20 @@ class TestFindPlaceholders(unittest.TestCase):
     def test_ignoruje_liczbe(self):
         self.assertEqual(find_placeholders("Kwota: [123.45]"), [])
 
+    def test_ignoruje_kwote_z_waluta(self):
+        # Kwota w nawiasie to dana, nie polecenie "wpisz tu coś" — fałszywy alarm
+        # o niewypełnionym polu blokuje wysyłkę gotowego pisma.
+        self.assertEqual(find_placeholders("Kwota: [123.45 zł]"), [])
+
+    def test_ignoruje_liczbe_z_jednostka(self):
+        self.assertEqual(find_placeholders("Termin: [14 dni]"), [])
+
+    def test_wykrywa_pole_zaczynajace_sie_od_slowa(self):
+        # Sufiks jednostki nie może wyłączyć wykrywania pól, które ZACZYNAJĄ się słowem.
+        self.assertEqual(
+            find_placeholders("Termin: [wpisz liczbę dni]"), ["[wpisz liczbę dni]"]
+        )
+
     def test_wiele_pol(self):
         t = "[data doręczenia] oraz [numer sprawy]"
         self.assertEqual(find_placeholders(t), ["[data doręczenia]", "[numer sprawy]"])
@@ -66,6 +80,11 @@ class TestFindAttachmentPageHeaders(unittest.TestCase):
 
     def test_brak(self):
         self.assertEqual(find_attachment_page_headers("Brak załączników."), [])
+
+    def test_skrot_nie_jest_naglowkiem(self):
+        # "zał. nr 2" to odesłanie w treści (find_cross_references), nie nagłówek strony
+        # załącznika. Liczenie go jako strony dawałoby fałszywy rozjazd lista↔strony.
+        self.assertEqual(find_attachment_page_headers("Zal. nr 2 - Faktura VAT"), [])
 
     def test_wiele(self):
         t = "Załącznik nr 1 — Umowa\nZałącznik nr 2 — Faktura"

--- a/scripts/test_kontrola_logika.py
+++ b/scripts/test_kontrola_logika.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unit testy logiki regex z kontrola-pisma.py. Tylko stdlib."""
+"""Unit testy logiki regex z kontrola_pisma.py. Tylko stdlib."""
 
 import unittest
 from kontrola_logika import (

--- a/skills/analiza-eml/SKILL.md
+++ b/skills/analiza-eml/SKILL.md
@@ -4,7 +4,7 @@ description: Analiza wiadomości e-mail (.eml) pod kątem dowodowym — droga wi
 when_to_use: Plik .eml w sprawie, spam, niezamówiona informacja handlowa, marketing bez zgody, nagłówki maila, kto naprawdę wysłał wiadomość, czy mail jest podszyciem.
 model: haiku
 effort: low
-allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/eml-forensics.py *)
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/eml_forensics.py *)
 ---
 
 # Analiza dowodowa wiadomości e-mail
@@ -12,7 +12,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/eml-forensics.py *)
 Robotę wykonuje skrypt. Twoim zadaniem jest go uruchomić i opisać wynik — nie liczyć niczego ręcznie.
 
 ```
-${CLAUDE_PLUGIN_ROOT}/scripts/eml-forensics.py <plik.eml> --outdir <sprawa>/ARCHIWUM
+${CLAUDE_PLUGIN_ROOT}/scripts/eml_forensics.py <plik.eml> --outdir <sprawa>/ARCHIWUM
 ```
 
 Skrypt zapisuje obok oryginału: `_naglowki.txt`, `_tresc.html`, `_analiza.md` (gotowy raport
@@ -69,7 +69,7 @@ samodzielnym dowodem — zestaw ją z nimi, nie przedstawiaj osobno.
 
 ## Po analizie
 
-1. Wynik `_analiza.md` dołącz do pisma jako załącznik (`build-pismo.py -z`).
+1. Wynik `_analiza.md` dołącz do pisma jako załącznik (`build_pismo.py -z`).
 2. Sprawdź domeny w RDAP i zapisz łańcuch przekierowań (`podmiot.sh domena` / `podmiot.sh strona`)
    — przekierowanie może zniknąć, więc trzeba je udokumentować teraz.
 3. Zaktualizuj manifest i chronologię (`/kruczek:dowod` robi to za ciebie).

--- a/skills/dowod/SKILL.md
+++ b/skills/dowod/SKILL.md
@@ -5,7 +5,7 @@ argument-hint: "[ścieżka do pliku] [katalog sprawy]"
 disable-model-invocation: true
 model: haiku
 effort: low
-allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/eml-forensics.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/manifest.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/metadane.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/archiwa.sh *) Bash(cp *) Bash(mkdir *) Bash(sha256sum *) Bash(file *) Bash(ls *) Bash(qpdf *) Bash(unzip *) Bash(7z *) Read Write Edit
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/eml_forensics.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/manifest.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/metadane.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/archiwa.sh *) Bash(cp *) Bash(mkdir *) Bash(sha256sum *) Bash(file *) Bash(ls *) Bash(qpdf *) Bash(unzip *) Bash(7z *) Read Write Edit
 ---
 
 # Wciągnięcie dowodu do archiwum
@@ -66,7 +66,7 @@ cp <źródło> <sprawa>/ARCHIWUM/<nazwa-wg-konwencji>
 
 ### `.eml` / `.msg`
 ```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/eml-forensics.py <plik> --outdir <sprawa>/ARCHIWUM
+${CLAUDE_PLUGIN_ROOT}/scripts/eml_forensics.py <plik> --outdir <sprawa>/ARCHIWUM
 ```
 Zleć subagentowi `analizuj-eml` (haiku).
 
@@ -120,7 +120,7 @@ Gdy dane nadawcy są puste — zrób sam zrzut lokalny, a `save` dopisz do TODO.
 
 | Typ | Co zrobić | Plik wynikowy |
 |---|---|---|
-| `.eml` / `.msg` | `eml-forensics.py` (krok 5) | `_naglowki.txt`, `_tresc.html`, `_analiza.md` |
+| `.eml` / `.msg` | `eml_forensics.py` (krok 5) | `_naglowki.txt`, `_tresc.html`, `_analiza.md` |
 | skan / zdjęcie / PDF bez tekstu | `transkrybuj` (sonnet) | `<nazwa>_tekst.md` |
 | PDF z warstwą tekstową | `pdftotext -layout` | `<nazwa>_tekst.md` |
 | nagranie audio / wideo | `transkrybuj` (sonnet) | `<nazwa>_tekst.md` |

--- a/skills/komendy/SKILL.md
+++ b/skills/komendy/SKILL.md
@@ -75,14 +75,14 @@ a jeśli z rozmowy wynika konkretna potrzeba — wskaż jedną, właściwą pozy
 | `init-projekt.sh` | struktura repozytorium |
 | `gen-claude-md.sh` | generuje CLAUDE.md z danych nadawcy (wołany też przez init-projekt.sh) |
 | `nowa-sprawa.sh` | katalog sprawy + `index.md` |
-| `eml-forensics.py` | pełna analiza `.eml` → raport markdown |
+| `eml_forensics.py` | pełna analiza `.eml` → raport markdown |
 | `manifest.py` | sumy kontrolne, manifest, weryfikacja spójności |
 | `eli.sh` | API ELI Sejmu: teksty ujednolicone, status aktu, nowelizacje |
 | `orzecznictwo.sh` | SAOS, UODO, CBOSA, SN, Dziennik Urzędowy UKE |
 | `podmiot.sh` | biała lista VAT, KRS, RDAP, przekierowania |
 | `dns.sh` | rekordy DNS, SPF/DKIM/DMARC, porównanie infrastruktury domen |
-| `build-pismo.py` | HTML → PDF z wdrukowanymi załącznikami, marginesy pod Envelo i e-Doręczenia |
-| `kontrola-pisma.py` | mechaniczna kontrola spójności gotowego pisma |
+| `build_pismo.py` | HTML → PDF z wdrukowanymi załącznikami, marginesy pod Envelo i e-Doręczenia |
+| `kontrola_pisma.py` | mechaniczna kontrola spójności gotowego pisma |
 | `archiwa.sh` | Wayback Machine CDX, Save Page Now, diff snapshotów |
 | `metadane.sh` | zbiorcza tabela metadanych PDF/DOCX/XLSX/obrazów z flagami rozbieżności |
 

--- a/skills/kontrola/SKILL.md
+++ b/skills/kontrola/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: kontrola
-description: "Mechaniczna kontrola gotowego pisma przed przekazaniem użytkownikowi — niewypełnione pola, ciągłość numeracji, zgodność nazw i numerów załączników w treści i na stronach załączników, sumy kontrolne, wymogi druku. Uruchamiaj po każdym build-pismo.py, zanim pokażesz pismo."
+description: "Mechaniczna kontrola gotowego pisma przed przekazaniem użytkownikowi — niewypełnione pola, ciągłość numeracji, zgodność nazw i numerów załączników w treści i na stronach załączników, sumy kontrolne, wymogi druku. Uruchamiaj po każdym build_pismo.py, zanim pokażesz pismo."
 argument-hint: "[pismo.pdf] [katalog sprawy]"
 model: haiku
 effort: low
-allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/kontrola-pisma.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/manifest.py *) Bash(pdftotext *) Bash(unzip -l *) Read
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/kontrola_pisma.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/manifest.py *) Bash(pdftotext *) Bash(unzip -l *) Read
 ---
 
 # Kontrola mechaniczna pisma
@@ -20,7 +20,7 @@ zanim jej nie uruchomisz.
 ## Uruchom
 
 ```
-${CLAUDE_PLUGIN_ROOT}/scripts/kontrola-pisma.py <pismo.pdf> --sprawa <katalog-sprawy> --zip <dowody.zip>
+${CLAUDE_PLUGIN_ROOT}/scripts/kontrola_pisma.py <pismo.pdf> --sprawa <katalog-sprawy> --zip <dowody.zip>
 ${CLAUDE_PLUGIN_ROOT}/scripts/manifest.py sprawdz <katalog-sprawy>
 ```
 

--- a/skills/pismo/SKILL.md
+++ b/skills/pismo/SKILL.md
@@ -5,7 +5,7 @@ argument-hint: "[katalog sprawy] [rodzaj pisma]"
 disable-model-invocation: true
 model: opus
 effort: high
-allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/check-deps.sh) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/build-pismo.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/kontrola-pisma.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/eli.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/orzecznictwo.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/manifest.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/podmiot.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/dns.sh *) Bash(mkdir *) Bash(cp *) Bash(zip *) Bash(sha256sum *) Bash(date *) Read Write Edit
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/check-deps.sh) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/build_pismo.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/kontrola_pisma.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/eli.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/orzecznictwo.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/manifest.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/podmiot.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/dns.sh *) Bash(mkdir *) Bash(cp *) Bash(zip *) Bash(sha256sum *) Bash(date *) Read Write Edit
 ---
 
 # Budowa pisma
@@ -134,7 +134,7 @@ Skutki: tylko kroki, które naprawdę zostaną podjęte.
 mkdir -p <sprawa>/<RRRR_MM_DD>-<CO>-<DO_KOGO>-DO_WYSYLKI/ROBOCZE
 cp ${CLAUDE_PLUGIN_ROOT}/templates/pismo.html <wysylka>/ROBOCZE/pismo.html
 # uzupełnij treść; z wypełnionych pól USUŃ class="fill"
-${CLAUDE_PLUGIN_ROOT}/scripts/build-pismo.py <wysylka>/ROBOCZE/pismo.html \
+${CLAUDE_PLUGIN_ROOT}/scripts/build_pismo.py <wysylka>/ROBOCZE/pismo.html \
     -o <wysylka>/<RRRR-MM-DD>_<Rodzaj>_<Adresat>.pdf \
     -z <sprawa>/ARCHIWUM/<dowod>.md:"Tytuł załącznika" \
     --stopka "<Rodzaj pisma> z <data>"

--- a/skills/recenzja/SKILL.md
+++ b/skills/recenzja/SKILL.md
@@ -5,7 +5,7 @@ argument-hint: "[katalog wysyłki lub pismo.pdf]"
 disable-model-invocation: true
 model: opus
 effort: high
-allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/eli.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/orzecznictwo.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/kontrola-pisma.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/manifest.py *) Bash(pdftotext *) Read Grep Glob
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/eli.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/orzecznictwo.sh *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/kontrola_pisma.py *) Bash(${CLAUDE_PLUGIN_ROOT}/scripts/manifest.py *) Bash(pdftotext *) Read Grep Glob
 ---
 
 # Recenzja pisma przed wysyłką

--- a/skills/redagowanie-pism/SKILL.md
+++ b/skills/redagowanie-pism/SKILL.md
@@ -26,7 +26,7 @@ Nie ma przepisu narzucającego krój ani stopień pisma w pismach procesowych �
 k.p.c. milczy, zarządzenie MS o sekretariatach sądowych też. Ale skoro Sąd UE wymaga min. 12 pt
 i marginesów 2,5 cm, to jest dobry punkt odniesienia i trzymamy się go wszędzie.
 
-Szablon: `${CLAUDE_PLUGIN_ROOT}/templates/pismo.html`. Składanie: `build-pismo.py` (ustawia
+Szablon: `${CLAUDE_PLUGIN_ROOT}/templates/pismo.html`. Składanie: `build_pismo.py` (ustawia
 marginesy sam). Nie zmieniaj marginesów bez powodu.
 
 ---
@@ -163,13 +163,13 @@ Lista **po podpisie**, na końcu pisma, pod nagłówkiem `Załączniki:`. Numera
 W treści odsyłasz `(zał. 3)`. Na samej stronie załącznika nagłówek `Załącznik nr 3 — <tytuł>`.
 
 **Tytuł na liście i tytuł na stronie załącznika muszą być identyczne.** Rozjazd tych dwóch to
-klasyczny błąd, przez który odbiorca twierdzi, że czegoś nie dostał. `kontrola-pisma.py` to sprawdza.
+klasyczny błąd, przez który odbiorca twierdzi, że czegoś nie dostał. `kontrola_pisma.py` to sprawdza.
 
 Wymienienie załączników jest obowiązkowe w piśmie procesowym (art. 126 § 1 pkt 7 k.p.c.), a same
 załączniki trzeba dołączyć (§ 1¹). Do sądu dołącza się też **odpisy dla stron przeciwnych**
 (art. 128 § 1 k.p.c.) — pamiętaj o tym przy liczeniu egzemplarzy.
 
-Przy wysyłce papierowej **załączniki wdrukuj w PDF** (`build-pismo.py -z`), żeby wydruk był
+Przy wysyłce papierowej **załączniki wdrukuj w PDF** (`build_pismo.py -z`), żeby wydruk był
 kompletny bez dokładania czegokolwiek. Równolegle `dowody.zip` do wysyłki elektronicznej,
 z `SHA256SUMS.txt` w środku.
 


### PR DESCRIPTION
## WHY

**Pokrycie testami nie było dotąd mierzone, więc luka w testach ujawniała się dopiero jako błąd na żywym organizmie.**

Repo ma testy (`test_kontrola_logika.py`, doctesty w `utils.py`) i solidny smoketest, ale nikt nie widzi, czego one nie dotykają.

## WHAT

Job ubuntu-owy liczy pokrycie przez `coverage.py` i wysyła raport do codecov.io. Statusy są informacyjne — codecov komentuje zmianę, ale nie blokuje PR-a.

## HOW

- `.coveragerc` — zakres pomiaru i uzasadnienie granicy.
- `codecov.yml` — statusy `informational`, komentarz tylko przy zmianie.
- `.github/workflows/smoketest.yml` — `setup-python` → `coverage run --parallel-mode` → `combine`/`report`/`xml` → `codecov/codecov-action@v5`.
- `.gitignore` — artefakty pomiaru.

`setup-python` zamiast systemowego `python3`, bo Ubuntu oznacza swojego interpretera jako externally managed (PEP 668) i gołe `pip install` kończy się błędem. Wszystko przez `python -m`, żeby nie zależeć od PATH.

### Co jest mierzone i dlaczego akurat to

Skrypty CLI mają myślnik w nazwie (`build-pismo.py`, `kontrola-pisma.py`, `eml-forensics.py`, `dane-nadawcy-status.py`), a myślnik jest niedozwolony w nazwie modułu Pythona — **nie da się ich zaimportować w teście**. Dokładnie dlatego istnieje osobne `kontrola_logika.py`. Smoketest uruchamia je jako osobne procesy, których `coverage` nie widzi bez `COVERAGE_PROCESS_START`; ta maszyneria jest krucha na dwóch systemach naraz, więc zamiast raportować dla nich nieprawdziwe 0% — świadomie ich nie mierzymy.

`manifest.py` jest mierzony mimo braku testów: jest importowalny, więc 0% jest tu prawdziwym zdaniem o stanie pokrycia, a nie artefaktem narzędzia. To główny powód, dla którego TOTAL wychodzi 31%, a nie ~90%.

Pomiar tylko na ubuntu. Job macOS zostaje na gołym `python3` — jest od regresji specyficznych dla bash 3.2, nie od metryk, a drugi upload tego samego pomiaru zaszumiłby raport.

## Stan lokalny

```
scripts/kontrola_logika.py      37      0   100%
scripts/manifest.py             95     95     0%
scripts/utils.py                12      5    58%
TOTAL                          144    100    31%
```

## Acceptance Criteria

- Gotowe, gdy job ubuntu-owy produkuje `coverage.xml` i wysyła go do codecov.
- Gotowe, gdy nieudany upload nie wywraca buildu (`fail_ci_if_error: false`).
- Gotowe, gdy job macOS działa bez zmian.
- Gotowe, gdy artefakty pomiaru nie trafiają do repo.

## Do rozważenia później

Gdy logika zostanie wyjęta z pozostałych skryptów do modułów `*_logika.py` i obudowana testami — warto wrócić do `codecov.yml` i przestawić statusy na blokujące.
