### PR TITLE
fix(ci): moduły eml_forensics wykluczone też z uruchomienia bezpośredniego

### DIFF
--- a/scripts/eml_forensics.py
+++ b/scripts/eml_forensics.py
@@ -361,13 +361,13 @@ def collect_declared_identifiers(msg: email.message.Message) -> tuple[str, ...]:
             found.append(value)
 
     for raw in msg.get_all("List-Id") or []:
-        etykieta = re.sub(r"[<>]", "", str(raw)).strip().split(".")[0]
-        if re.fullmatch(r"[0-9]+", etykieta):
-            add(etykieta)
+        label = re.sub(r"[<>]", "", str(raw)).strip().split(".")[0]
+        if re.fullmatch(r"[0-9]+", label):
+            add(label)
     for raw in msg.get_all("Feedback-ID") or []:
-        for pole in str(raw).split(":"):
-            if re.fullmatch(r"[0-9]{4,}", pole.strip()):
-                add(pole.strip())
+        for field in str(raw).split(":"):
+            if re.fullmatch(r"[0-9]{4,}", field.strip()):
+                add(field.strip())
     return tuple(found)
 
 
@@ -462,8 +462,8 @@ def build_report(eml_path: Path, outdir: Path) -> tuple[str, Path]:
         msg.get("Subject"),
         msg.get("Date"),
         tuple(
-            (nazwa, raw_header_value(raw_headers, nazwa), msg.get(nazwa))
-            for nazwa in ("Subject", "Date", "From", "Reply-To", "To")
+            (name, raw_header_value(raw_headers, name), msg.get(name))
+            for name in ("Subject", "Date", "From", "Reply-To", "To")
         ),
         header_names(msg),
         W,
@@ -537,7 +537,7 @@ def build_report(eml_path: Path, outdir: Path) -> tuple[str, Path]:
     stat = eml_path.stat()
     # Identyfikatory szukane w treści WIDOCZNEJ (obie części), nie w nagłówkach —
     # numer rachunku i dane rejestrowe stoją w stopce wiadomości.
-    tresc_do_skanu = " ".join(
+    scannable_text = " ".join(
         filter(None, [deobfuscate(html_body) if html_body else None, text_body])
     )
     mtime = datetime.datetime.fromtimestamp(stat.st_mtime).astimezone().isoformat()
@@ -553,7 +553,7 @@ def build_report(eml_path: Path, outdir: Path) -> tuple[str, Path]:
     )
     write_identity_layers_section(
         identity_layers(msg, dkim, resources),
-        registry_identifiers(tresc_do_skanu),
+        registry_identifiers(scannable_text),
         W,
     )
 

--- a/scripts/eml_forensics_logika.py
+++ b/scripts/eml_forensics_logika.py
@@ -2382,8 +2382,20 @@ def find_hidden_elements(src: str) -> list[HiddenElement]:
     >>> el = find_hidden_elements('<span style="display:none;opacity:0"></span>')[0]
     >>> el.text, el.kind
     ('', 'ukrywające')
+
+    Element zapisany wewnątrz komentarza HTML **nie jest** treścią dokumentu —
+    liczenie go jako ukrytego dawało dowód na coś, czego odbiorca nie dostał:
+
+    >>> find_hidden_elements(
+    ...     '<!-- <div style="display:none">w komentarzu</div> --><p>widoczne</p>')
+    []
     """
     out: list[HiddenElement] = []
+    # Komentarz HTML nie jest treścią dokumentu. Element z regułą ukrywającą
+    # zapisany WEWNĄTRZ komentarza był liczony jako ukryta treść — czyli dowód
+    # na coś, czego odbiorca nie dostał. Wygaszamy komentarze zachowując
+    # długość, żeby pozycje w `src` pozostały zgodne.
+    src = re.sub(r"<!--.*?-->", lambda m: " " * len(m.group(0)), src, flags=re.DOTALL)
     # Skanujemy znaczniki OTWIERAJĄCE. Wzorzec wymagający pary `<tag>…</tag>`
     # konsumował zagnieżdżone elementy i przy 27 komórkach `<TD>` z regułą
     # ukrywającą raportował 9 — `finditer` nie zwraca dopasowań nakładających się.
@@ -2507,13 +2519,72 @@ def background_for_element(
     return None
 
 
+#: Reguły warunkowe: ich ciało obowiązuje tylko przy spełnionym warunku.
+CONDITIONAL_AT_RULES = ("media", "supports", "container")
+
+#: Reguły, których ciało NIE jest treścią strony. `@keyframes fade{from{opacity:0}}`
+#: to klatka animacji, nie ukryta treść — liczone jako reguła ukrywająca dawało
+#: dowód na ukrywanie, którego plik nie zawiera.
+NON_CONTENT_AT_RULES = ("keyframes", "font-face", "counter-style", "page", "property")
+
+
+def _blank_css_noise(css: str, strings: bool = True) -> str:
+    """Wygasza komentarze (i opcjonalnie stringi/`url()`), zachowując DŁUGOŚĆ.
+
+    Klamra w komentarzu albo w wartości tekstowej nie jest klamrą struktury.
+    Ręczne liczenie klamer brało ją za prawdziwą i wypisywało w raporcie
+    selektor sklejony ze śmieciem.
+
+    Długość wyniku jest identyczna z wejściem, bo indeksy z wygaszonej wersji
+    tną wersję oryginalną — rozjazd o jeden znak gubi całą regułę.
+
+    >>> len(_blank_css_noise('/* } */ .a{display:none}')) == len('/* } */ .a{display:none}')
+    True
+    >>> _blank_css_noise('/* } */ .a{display:none}').strip()
+    '.a{display:none}'
+    >>> _blank_css_noise('.a::before{content:"}"}')
+    '.a::before{content:   }'
+
+    Wersja bez wygaszania stringów zachowuje selektor atrybutowy:
+
+    >>> _blank_css_noise('[title="a}b"]{display:none}', strings=False)
+    '[title="a}b"]{display:none}'
+    """
+    out: list[str] = []
+    i, n = 0, len(css)
+    while i < n:
+        if css[i : i + 2] == "/*":
+            end = css.find("*/", i + 2)
+            end = n if end < 0 else end + 2
+            out.append(" " * (end - i))
+            i = end
+            continue
+        ch = css[i]
+        if strings and ch in "\"'":
+            j = i + 1
+            while j < n and css[j] != ch:
+                j += 2 if css[j] == "\\" else 1
+            j = min(j, n - 1)
+            out.append(" " * (j - i + 1))
+            i = j + 1
+            continue
+        if strings and css[i : i + 4].lower() == "url(":
+            end = css.find(")", i)
+            end = n - 1 if end < 0 else end
+            out.append(" " * (end - i + 1))
+            i = end + 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def _rules_with_conditions(block: str) -> list[tuple[str, str, str | None]]:
     """Reguły z bloku CSS jako `(selektor, deklaracje, warunek)`.
 
     Reguły zagnieżdżone w `@media`/`@supports` niosą swój warunek; pozostałe
-    mają `None`. Wcześniejszy parser dopasowywał `([^{}]+)\\{([^{}]*)\\}`, więc
-    nagłówek `@media …` traktował jak zwykły selektor, a jego zawartość jako
-    reguły bezwarunkowe.
+    mają `None`. Skanowanie klamer idzie po wersji z wygaszonymi komentarzami
+    i stringami, a treść czytana jest z wersji zachowującej stringi.
 
     >>> _rules_with_conditions('.a{display:none}')
     [('.a', 'display:none', None)]
@@ -2523,40 +2594,82 @@ def _rules_with_conditions(block: str) -> list[tuple[str, str, str | None]]:
     [('.a', 'color:red', None), ('.b', 'display:none', '@media print'), ('.c', 'margin:0', None)]
     >>> _rules_with_conditions('')
     []
+
+    Komentarz z klamrą nie jest strukturą — wcześniej wciekał do selektora:
+
+    >>> _rules_with_conditions('/* } */ .a{display:none}')
+    [('.a', 'display:none', None)]
+
+    Klamra w wartości tekstowej też nie:
+
+    >>> _rules_with_conditions('.x::before{content:"}"} .a{display:none}')[-1]
+    ('.a', 'display:none', None)
+
+    Selektor atrybutowy zachowuje swoją wartość:
+
+    >>> _rules_with_conditions('[title="a}b"]{display:none}')
+    [('[title="a}b"]', 'display:none', None)]
+
+    Warunki się **kumulują** — reguła w `@media` wewnątrz `@supports` obowiązuje
+    tylko wtedy, gdy spełnione są oba:
+
+    >>> _rules_with_conditions(
+    ...     '@supports (display:grid){@media (max-width:600px){.a{display:none}}}')
+    [('.a', 'display:none', '@supports (display:grid) i @media (max-width:600px)')]
+
+    `@keyframes` to klatki animacji, nie treść strony. Liczone jako reguła
+    ukrywająca dawały dowód na ukrywanie, którego plik nie zawiera:
+
+    >>> _rules_with_conditions('@keyframes fade{from{opacity:0}to{opacity:1}}')
+    []
+
+    Lista selektorów rozbija się na osobne reguły:
+
+    >>> [sel for sel, _, _ in _rules_with_conditions('.a, .b{display:none}')]
+    ['.a', '.b']
     """
+    return _rules_in(block, ())
+
+
+def _rules_in(
+    block: str, conditions: tuple[str, ...]
+) -> list[tuple[str, str, str | None]]:
+    """Rekurencyjny krok `_rules_with_conditions`, ze stosem warunków."""
+    scan = _blank_css_noise(block)
+    readable = _blank_css_noise(block, strings=False)
     out: list[tuple[str, str, str | None]] = []
-    pos = 0
-    while pos < len(block):
-        opening = block.find("{", pos)
-        if opening < 0:
+    i, n = 0, len(scan)
+    while i < n:
+        brace = scan.find("{", i)
+        if brace < 0:
             break
-        prelude = block[pos:opening].strip()
-        if prelude.startswith("@") and re.match(
-            r"@(media|supports|container)\b", prelude
-        ):
-            # Reguła warunkowa: jej ciało zawiera kolejne reguły. Szukamy
-            # domykającej klamry pary, żeby nie uciąć bloku na pierwszym `}`.
-            depth, index = 1, opening + 1
-            while index < len(block) and depth:
-                if block[index] == "{":
-                    depth += 1
-                elif block[index] == "}":
-                    depth -= 1
-                index += 1
-            condition = re.sub(r"\s+", " ", prelude)
-            for selector, body, nested in _rules_with_conditions(
-                block[opening + 1 : index - 1]
-            ):
-                out.append((selector, body, nested or condition))
-            pos = index
-            continue
-        closing = block.find("}", opening)
-        if closing < 0:
-            break
-        selector = prelude
-        if selector:
-            out.append((selector, block[opening + 1 : closing].strip(), None))
-        pos = closing + 1
+        prelude = readable[i:brace].strip()
+        depth, j = 1, brace + 1
+        while j < n and depth:
+            if scan[j] == "{":
+                depth += 1
+            elif scan[j] == "}":
+                depth -= 1
+            j += 1
+        body_raw = block[brace + 1 : j - 1]
+        if prelude.startswith("@"):
+            named = re.match(r"@([a-zA-Z-]+)", prelude)
+            kind = named.group(1).lower() if named else ""
+            if kind in CONDITIONAL_AT_RULES:
+                out += _rules_in(body_raw, conditions + (re.sub(r"\s+", " ", prelude),))
+            # NON_CONTENT_AT_RULES pomijamy świadomie — to nie jest treść strony.
+        elif prelude:
+            body = re.sub(r"\s+", " ", readable[brace + 1 : j - 1].strip())
+            for selector in prelude.split(","):
+                if selector.strip():
+                    out.append(
+                        (
+                            selector.strip(),
+                            body,
+                            " i ".join(conditions) if conditions else None,
+                        )
+                    )
+        i = j
     return out
 
 

--- a/scripts/eml_forensics_logika.py
+++ b/scripts/eml_forensics_logika.py
@@ -410,10 +410,10 @@ class DkimSignature:
             body_length=as_int("l"),
             identity=tags.get("i", "").strip() or None,
             other_tags=tuple(
-                (klucz, wartosc.strip())
-                for klucz, wartosc in tags.items()
+                (klucz, value.strip())
+                for klucz, value in tags.items()
                 if klucz not in {"d", "s", "a", "c", "bh", "h", "t", "x", "l", "i"}
-                and wartosc.strip()
+                and value.strip()
             ),
         )
 
@@ -1352,17 +1352,17 @@ def received_chain_continuity(
     []
     """
     out: list[tuple[int, str, str, bool]] = []
-    for wczesniejszy, pozniejszy in itertools.pairwise(hops):
-        odbiorca = (wczesniejszy.by or "").rstrip(".").lower()
-        nadawca = (pozniejszy.helo or pozniejszy.rdns or "").rstrip(".").lower()
-        if not odbiorca or not nadawca:
+    for earlier, later in itertools.pairwise(hops):
+        receiver = (earlier.by or "").rstrip(".").lower()
+        sender = (later.helo or later.rdns or "").rstrip(".").lower()
+        if not receiver or not sender:
             continue
         out.append(
             (
-                wczesniejszy.index,
-                wczesniejszy.by or "",
-                pozniejszy.helo or pozniejszy.rdns or "",
-                odbiorca == nadawca,
+                earlier.index,
+                earlier.by or "",
+                later.helo or later.rdns or "",
+                receiver == sender,
             )
         )
     return out
@@ -1550,7 +1550,7 @@ def extract_timestamps(
     # Ta sama zasada dotyczy `In-Reply-To` i `References` niosących ten sam
     # identyfikator: to jedno źródło, nie dwa niezależne potwierdzenia.
     unikalne: list[tuple[str, datetime.datetime]] = []
-    widziane: set[tuple[str, float]] = set()
+    seen: set[tuple[str, float]] = set()
     for label, moment in result:
         # Adnotację w nawiasach kwadratowych (np. o nieustalonej strefie) zdejmujemy
         # przed wyliczeniem rodziny — inaczej `In-Reply-To` i `References` niosące
@@ -1563,9 +1563,9 @@ def extract_timestamps(
             else rodzina
         )
         klucz = (rodzina, moment.timestamp())
-        if klucz in widziane:
+        if klucz in seen:
             continue
-        widziane.add(klucz)
+        seen.add(klucz)
         unikalne.append((label, moment))
     return unikalne
 
@@ -1714,10 +1714,10 @@ def oversigned_headers(
     >>> oversigned_headers(msg, ("From", "Subject"))
     []
     """
-    obecne = {name.lower() for name in header_names(msg)}
+    present = {name.lower() for name in header_names(msg)}
     out: list[str] = []
     for name in signed:
-        if name.lower() not in obecne and name not in out:
+        if name.lower() not in present and name not in out:
             out.append(name)
     return out
 
@@ -2281,20 +2281,20 @@ def _element_inner(src: str, match: "re.Match[str]") -> str:
     return rest[: closing.start()] if closing else rest[:2000]
 
 
-def _kolor(deklaracja: str) -> str | None:
+def _colour(declaration: str) -> str | None:
     """Znormalizowany kolor z deklaracji CSS — do porównań tekst ↔ tło.
 
-    >>> _kolor("color:#FFFFFF")
+    >>> _colour("color:#FFFFFF")
     '#ffffff'
-    >>> _kolor("background-color: white")
+    >>> _colour("background-color: white")
     '#ffffff'
-    >>> _kolor("background:#000")
+    >>> _colour("background:#000")
     '#000000'
-    >>> _kolor("color:red") is None
+    >>> _colour("color:red") is None
     True
     """
     match = re.search(
-        r"#([0-9a-fA-F]{3,8})\b|\b(white|black)\b", deklaracja, re.IGNORECASE
+        r"#([0-9a-fA-F]{3,8})\b|\b(white|black)\b", declaration, re.IGNORECASE
     )
     if not match:
         return None
@@ -2306,25 +2306,25 @@ def _kolor(deklaracja: str) -> str | None:
     return "#" + hex_[:6]
 
 
-def tekst_zlewa_sie_z_tlem(style: str, background: str | None) -> bool:
+def text_blends_into_background(style: str, background: str | None) -> bool:
     """Czy zadeklarowany kolor tekstu jest identyczny z zadeklarowanym tłem.
 
     Samo istnienie tła nie wyklucza ukrycia — biały tekst na białym `body`
     to klasyczny przypadek, który przy regule „jest tło, więc pomijamy”
     wypadłby z raportu.
 
-    >>> tekst_zlewa_sie_z_tlem("color:#ffffff", "background-color:#ffffff (z <style>, body)")
+    >>> text_blends_into_background("color:#ffffff", "background-color:#ffffff (z <style>, body)")
     True
-    >>> tekst_zlewa_sie_z_tlem("color:#FFFFFF", "background-color:#1965F7")
+    >>> text_blends_into_background("color:#FFFFFF", "background-color:#1965F7")
     False
-    >>> tekst_zlewa_sie_z_tlem("color:#fff", None)
+    >>> text_blends_into_background("color:#fff", None)
     False
     """
     if not background:
         return False
-    tekst = _kolor(re.sub(r"background[^;]*", "", style, flags=re.IGNORECASE))
-    tlo = _kolor(background)
-    return bool(tekst and tlo and tekst == tlo)
+    text = _colour(re.sub(r"background[^;]*", "", style, flags=re.IGNORECASE))
+    background = _colour(background)
+    return bool(text and background and text == background)
 
 
 def find_hidden_elements(src: str) -> list[HiddenElement]:
@@ -2399,7 +2399,7 @@ def find_hidden_elements(src: str) -> list[HiddenElement]:
         r"<(?P<tag>div|span|p|td|tr|table|a|font)\b(?P<attrs>[^>]*)>",
         re.IGNORECASE,
     )
-    arkusz = stylesheet_declarations(src)
+    stylesheet = stylesheet_declarations(src)
     for match in pattern.finditer(src):
         style = _attr(match.group("attrs"), "style")
         if not style:
@@ -2409,20 +2409,22 @@ def find_hidden_elements(src: str) -> list[HiddenElement]:
         # biały tekst na czarnej stopce trafiał do sekcji o widoczności
         # z adnotacją „tło nieustalone”, choć plik zawierał odpowiedź.
         background = declared_background(style) or background_for_element(
-            match.group("attrs"), arkusz
+            match.group("attrs"), stylesheet
         )
         hiding = _hidden_rules(style)
         # Tło wyklucza regułę kontrastu tylko wtedy, gdy RÓŻNI SIĘ od koloru
         # tekstu. Zgodność (biały na białym) jest odwrotnie — najmocniejszym
         # przypadkiem w tej klasie, więc trafia do reguł ukrywających.
-        zlewa = tekst_zlewa_sie_z_tlem(style, background)
-        if zlewa:
-            hiding = hiding + [f"kolor tekstu identyczny z tłem ({_kolor(background)})"]
-        kolor = [] if (background and not zlewa) else _color_contrast_rules(style)
+        blends = text_blends_into_background(style, background)
+        if blends:
+            hiding = hiding + [
+                f"kolor tekstu identyczny z tłem ({_colour(background)})"
+            ]
+        colour = [] if (background and not blends) else _color_contrast_rules(style)
         # Krycie i rozmiar czcionki NIE zależą od tła, więc zadeklarowane tło
         # ich nie wyklucza. Wspólne wykluczanie z kolorem tekstu kasowało cały
         # element `opacity:0.96; background-color:#1965F7` — razem z jego treścią.
-        low_contrast = kolor + _dimming_rules(style)
+        low_contrast = colour + _dimming_rules(style)
         if not hiding and not low_contrast:
             continue
         inner = html.unescape(re.sub(r"<[^>]+>", " ", _element_inner(src, match)))
@@ -2460,26 +2462,28 @@ def stylesheet_declarations(src: str) -> dict[str, dict[str, str]]:
     {}
     """
     out: dict[str, dict[str, str]] = {}
-    for blok in re.findall(
+    for block in re.findall(
         r"<style\b[^>]*>(.*?)</style>", src, re.DOTALL | re.IGNORECASE
     ):
-        for selektor, cialo, warunek in _rules_with_conditions(blok):
-            if warunek is not None:
+        for selector, body, condition in _rules_with_conditions(block):
+            if condition is not None:
                 continue
-            deklaracje = {
+            declarations = {
                 k.strip().lower(): v.strip()
-                for k, v in re.findall(r"([a-zA-Z-]+)\s*:\s*([^;]+)", cialo)
+                for k, v in re.findall(r"([a-zA-Z-]+)\s*:\s*([^;]+)", body)
             }
-            if not deklaracje:
+            if not declarations:
                 continue
-            for pojedynczy in selektor.split(","):
-                nazwa = re.sub(r"\s+", " ", pojedynczy).strip()
-                if nazwa:
-                    out.setdefault(nazwa, {}).update(deklaracje)
+            for single in selector.split(","):
+                name = re.sub(r"\s+", " ", single).strip()
+                if name:
+                    out.setdefault(name, {}).update(declarations)
     return out
 
 
-def background_for_element(attrs: str, arkusz: dict[str, dict[str, str]]) -> str | None:
+def background_for_element(
+    attrs: str, stylesheet: dict[str, dict[str, str]]
+) -> str | None:
     """Tło elementu ustalone z jego `id`/`class` wobec reguł z bloków `<style>`.
 
     >>> arkusz = {"#stopka": {"background-color": "#000000"}}
@@ -2494,18 +2498,20 @@ def background_for_element(attrs: str, arkusz: dict[str, dict[str, str]]) -> str
     'background-color:#ffffff (z <style>, selektor body)'
     """
     element_id = _attr(attrs, "id")
-    klasy = (_attr(attrs, "class") or "").split()
+    classes = (_attr(attrs, "class") or "").split()
     # `body` na końcu: gdy element nie deklaruje własnego tła ani nie pasuje do
     # żadnego selektora, tło dziedziczy z dokumentu. Bez tego kroku biały tekst
     # przy `body{background-color:#ffffff}` zostawał jako „tło nieustalone”.
-    selektory = (
-        ([f"#{element_id}"] if element_id else []) + [f".{k}" for k in klasy] + ["body"]
+    selectors = (
+        ([f"#{element_id}"] if element_id else [])
+        + [f".{k}" for k in classes]
+        + ["body"]
     )
-    for selektor in selektory:
-        deklaracje = arkusz.get(selektor, {})
-        for wlasciwosc in ("background-color", "background"):
-            if wlasciwosc in deklaracje:
-                return f"{wlasciwosc}:{deklaracje[wlasciwosc]} (z <style>, selektor {selektor})"
+    for selector in selectors:
+        declarations = stylesheet.get(selector, {})
+        for prop in ("background-color", "background"):
+            if prop in declarations:
+                return f"{prop}:{declarations[prop]} (z <style>, selektor {selector})"
     return None
 
 
@@ -2830,16 +2836,22 @@ def extract_html_resources(src: str) -> list[HtmlResource]:
         )
 
     for match in re.finditer(
-        r"<a\b(?P<attrs>[^>]*)href=[\"'](?P<url>[^\"']+)[\"'][^>]*>(?P<text>.*?)</a>",
+        # `attrs` musi objąć CAŁY znacznik, nie tylko część przed `href`.
+        # Wcześniej atrybuty stojące za `href` — w tym `title` i `style` —
+        # były dla ekstraktora niewidoczne, więc kotwica z pustym tekstem
+        # i opisem wyłącznie w `title` trafiała do raportu jako „—”.
+        r"<a\b(?P<attrs>[^>]*?)href=[\"'](?P<url>[^\"']+)[\"'](?P<rest>[^>]*)>"
+        r"(?P<text>.*?)</a>",
         src,
         flags=re.DOTALL | re.IGNORECASE,
     ):
         text = html.unescape(re.sub(r"<[^>]+>", " ", match.group("text")))
         label = re.sub(r"\s+", " ", text).strip()
-        title = _attr(match.group("attrs"), "title")
+        attrs_all = match.group("attrs") + match.group("rest")
+        title = _attr(attrs_all, "title")
         if title:
             label = f"{label} (title: {title})" if label else f"(title: {title})"
-        add("a", match.group("url"), label, match.group("attrs"))
+        add("a", match.group("url"), label, attrs_all)
 
     for match in re.finditer(r"<img\b(?P<attrs>[^>]*)>", src, flags=re.IGNORECASE):
         attrs = match.group("attrs")
@@ -2878,9 +2890,9 @@ def extract_html_resources(src: str) -> list[HtmlResource]:
             continue
         if not re.search(r"(?<![-a-z])height:[01](?:px|pt)", normalized):
             continue
-        tlo = re.search(r"url\(\s*[\"']?([^\"')]+)", style, re.IGNORECASE)
-        if tlo:
-            add("beacon-css", tlo.group(1), None, match.group(1))
+        background = re.search(r"url\(\s*[\"']?([^\"')]+)", style, re.IGNORECASE)
+        if background:
+            add("beacon-css", background.group(1), None, match.group(1))
 
     # Outlook VML: <v:fill src="..."> to ten sam zasób co tło CSS, innym zapisem.
     for match in re.finditer(r"<v:fill\b([^>]*)>", src, flags=re.IGNORECASE):
@@ -3095,8 +3107,8 @@ def document_metadata(src: str) -> list[tuple[str, str]]:
             r"<(?!html)[a-z]+\b[^>]*\blang\s*=\s*[\"']([^\"']+)", src, re.IGNORECASE
         )
     )
-    for jezyk, ile in pozostale.most_common():
-        out.append(("lang w elementach", f"{jezyk} ({ile}×)"))
+    for jezyk, count in pozostale.most_common():
+        out.append(("lang w elementach", f"{jezyk} ({count}×)"))
     return out
 
 
@@ -3258,12 +3270,12 @@ def describe_uuid(value: str) -> str | None:
         version_ok = value[14].lower() in "12345678"
         variant_ok = value[19].lower() in "89ab"
         if version_ok and not variant_ok:
-            powod = "pole wariantu spoza RFC 4122"
+            reason = "pole wariantu spoza RFC 4122"
         elif variant_ok and not version_ok:
-            powod = f"pole wersji `{value[14]}` spoza zakresu 1–8"
+            reason = f"pole wersji `{value[14]}` spoza zakresu 1–8"
         else:
-            powod = "pola wersji i wariantu spoza RFC 4122"
-        return f"hex w formacie 8-4-4-4-12 ({powod} — nie UUID)"
+            reason = "pola wersji i wariantu spoza RFC 4122"
+        return f"hex w formacie 8-4-4-4-12 ({reason} — nie UUID)"
     version = int(match.group(3))
     if version != 1:
         return f"UUID wersja {version}"
@@ -3334,9 +3346,9 @@ def falszywy_ksztalt(value: str) -> str | None:
     >>> falszywy_ksztalt("YTo1OntzOjY6InNvdXJjZSI7") is None
     True
     """
-    for wzorzec, opis in NIE_TOKENY:
-        if re.fullmatch(wzorzec, value):
-            return opis
+    for pattern, description in NIE_TOKENY:
+        if re.fullmatch(pattern, value):
+            return description
     return None
 
 
@@ -3841,11 +3853,11 @@ def repeated_identifiers(
             # UUID najpierw i w całości. Skaner `[A-Za-z0-9]{8,}` rozcinał go na
             # myślnikach i wpisywał do tabeli cztery „niezależne identyfikatory”
             # zamiast jednego — a każdy fragment z osobna nie jest identyfikatorem.
-            reszta = haystack
+            rest = haystack
             for uuid_match in re.finditer(UUID_PATTERN, haystack, re.IGNORECASE):
                 note(uuid_match.group(0), label)
-                reszta = reszta.replace(uuid_match.group(0), " ")
-            for found in set(re.findall(rf"[A-Za-z0-9]{{{min_length},}}", reszta)):
+                rest = rest.replace(uuid_match.group(0), " ")
+            for found in set(re.findall(rf"[A-Za-z0-9]{{{min_length},}}", rest)):
                 # Etykieta domeny (`newsletter`, `marketing`, `powiadomienia`)
                 # to nie identyfikator odbiorcy ani kampanii — powiązania między
                 # nazwami opisuje inwentarz domen. Skaner wpisywał je do tabeli
@@ -4211,13 +4223,13 @@ def software_fingerprints(
     # i `User-Agent`, więc dla wiadomości z czterema nagłówkami `X-sare*`
     # nazywającymi system wprost drukowała „brak śladów oprogramowania” —
     # ustalenie sprzeczne z zawartością pliku.
-    for nazwa in msg:
+    for name in msg:
         if re.match(
-            r"(?i)^x-(sare|sg|ses|campaign|mailer-|esp|sendgrid|mailgun)", nazwa
+            r"(?i)^x-(sare|sg|ses|campaign|mailer-|esp|sendgrid|mailgun)", name
         ):
-            wartosc = str(msg.get(nazwa) or "").strip()
-            if wartosc and (nazwa, wartosc) not in out:
-                out.append((nazwa, wartosc[:200]))
+            value = str(msg.get(name) or "").strip()
+            if value and (name, value) not in out:
+                out.append((name, value[:200]))
 
     # Format części lokalnej `Message-ID` bywa sygnaturą oprogramowania: `E`
     # + długi identyfikator to kolejka Exima, `----=_Part_N_M.epoch` w boundary
@@ -4240,9 +4252,9 @@ def software_fingerprints(
             r"\((Exim|Postfix|Sendmail|qmail|OpenSMTPD|MailEnable)\b[^)]*\)", str(raw)
         )
         if mta:
-            wartosc = mta.group(0).strip("()")
-            if ("MTA z nagłówka Received", wartosc) not in out:
-                out.append(("MTA z nagłówka Received", wartosc))
+            value = mta.group(0).strip("()")
+            if ("MTA z nagłówka Received", value) not in out:
+                out.append(("MTA z nagłówka Received", value))
 
     for name in ("X-Mailer", "User-Agent"):
         if msg.get(name) is None:
@@ -4265,7 +4277,7 @@ def software_fingerprints(
         # Pozostałe znaczniki `<meta>` i przestrzenie nazw. Raport wyłapywał
         # `Cocoa HTML Writer`, a gubił `CocoaVersion`, `MSHTML` i deklaracje
         # `xmlns:v`/`xmlns:o` — czyli resztę odcisku tego samego środowiska.
-        for wzorzec, etykieta in (
+        for pattern, label in (
             (
                 r'<meta[^>]+name=["\']?CocoaVersion["\']?[^>]+content=["\']?([^"\'>]+)',
                 "meta CocoaVersion",
@@ -4274,9 +4286,9 @@ def software_fingerprints(
             (r'xmlns:(?:v|o|w|x)\s*=\s*["\']?([^"\'\s>]+)', "Przestrzeń nazw XML"),
             (r'(font-family\s*:\s*Aptos[^;"\']*)', "Deklaracja kroju"),
         ):
-            found = list(dict.fromkeys(re.findall(wzorzec, html_body, re.IGNORECASE)))
+            found = list(dict.fromkeys(re.findall(pattern, html_body, re.IGNORECASE)))
             if found:
-                out.append((etykieta, ", ".join(found[:6])))
+                out.append((label, ", ".join(found[:6])))
 
         # Dark Reader wstrzykuje swoje atrybuty w przeglądarce, po stronie
         # odbiorcy strony. Ich obecność w WYSŁANYM HTML-u to ślad autorski,
@@ -4312,28 +4324,31 @@ def software_fingerprints(
         # Ucinanie do 4 znaków i lowercase robiło z jednej rodziny `mcn*` trzy
         # nieistniejące (`mcni`, `mcnd`, `mcnt`), a z sześciu różnych klas
         # Gmaila — jedną `gmai`. Wielkość liter jest częścią dowodu.
-        klasy = collections.Counter(
-            nazwa
+        classes = collections.Counter(
+            name
             for atrybut in re.findall(r"""class\s*=\s*["']([^"']+)""", html_body)
-            for nazwa in atrybut.split()
+            for name in atrybut.split()
         )
-        czolowe = [(n, c) for n, c in klasy.most_common(8) if c >= 2]
-        if czolowe:
+        most_common = [(n, c) for n, c in classes.most_common(8) if c >= 2]
+        if most_common:
             out.append(
-                ("Najczęstsze klasy CSS", ", ".join(f"{n} ({c}×)" for n, c in czolowe))
+                (
+                    "Najczęstsze klasy CSS",
+                    ", ".join(f"{n} ({c}×)" for n, c in most_common),
+                )
             )
         # Artefakty rozszerzeń przeglądarki i edytorów WYSIWYG obecne w wysłanym
         # źródle to ustalenie o pochodzeniu HTML-a; 64 takie atrybuty w jednym
         # pliku nie zostały odnotowane ani razu.
-        for wzorzec, etykieta in (
+        for pattern, label in (
             (r"data-darkreader-[a-z-]+", "Atrybuty DarkReader"),
             (r"--darkreader-[a-z-]+", "Zmienne CSS DarkReader"),
             (r"contenteditable\s*=", "Atrybut contenteditable (edytor WYSIWYG)"),
             (r"data-template-container", "Atrybut data-template-container"),
         ):
-            ile = len(re.findall(wzorzec, html_body, re.IGNORECASE))
-            if ile:
-                out.append((etykieta, f"{ile} wystąpień"))
+            count = len(re.findall(pattern, html_body, re.IGNORECASE))
+            if count:
+                out.append((label, f"{count} wystąpień"))
     return out
 
 
@@ -4428,12 +4443,12 @@ def _iban_valid(iban: str) -> bool:
     >>> _iban_valid("PL17109028510000000130176425")
     False
     """
-    znaki = re.sub(r"\s", "", iban).upper()
-    if not re.fullmatch(r"[A-Z]{2}\d{2}[A-Z0-9]{10,30}", znaki):
+    chars = re.sub(r"\s", "", iban).upper()
+    if not re.fullmatch(r"[A-Z]{2}\d{2}[A-Z0-9]{10,30}", chars):
         return False
-    przestawione = znaki[4:] + znaki[:4]
-    cyfry = "".join(str(ord(z) - 55) if z.isalpha() else z for z in przestawione)
-    return int(cyfry) % 97 == 1
+    rotated = chars[4:] + chars[:4]
+    digits = "".join(str(ord(z) - 55) if z.isalpha() else z for z in rotated)
+    return int(digits) % 97 == 1
 
 
 def _nip_valid(nip: str) -> bool:
@@ -4446,12 +4461,12 @@ def _nip_valid(nip: str) -> bool:
     >>> _nip_valid("123")
     False
     """
-    cyfry = re.sub(r"\D", "", nip)
-    if len(cyfry) != 10:
+    digits = re.sub(r"\D", "", nip)
+    if len(digits) != 10:
         return False
-    wagi = (6, 5, 7, 2, 3, 4, 5, 6, 7)
-    suma = sum(w * int(c) for w, c in zip(wagi, cyfry))
-    return suma % 11 == int(cyfry[9])
+    weights = (6, 5, 7, 2, 3, 4, 5, 6, 7)
+    total = sum(w * int(c) for w, c in zip(weights, digits))
+    return total % 11 == int(digits[9])
 
 
 def _regon_valid(regon: str) -> bool:
@@ -4462,12 +4477,12 @@ def _regon_valid(regon: str) -> bool:
     >>> _regon_valid("123456789")
     False
     """
-    cyfry = re.sub(r"\D", "", regon)
-    wagi = {9: (8, 9, 2, 3, 4, 5, 6, 7), 14: (2, 4, 8, 5, 0, 9, 7, 3, 6, 1, 2, 4, 8)}
-    if len(cyfry) not in wagi:
+    digits = re.sub(r"\D", "", regon)
+    weights = {9: (8, 9, 2, 3, 4, 5, 6, 7), 14: (2, 4, 8, 5, 0, 9, 7, 3, 6, 1, 2, 4, 8)}
+    if len(digits) not in weights:
         return False
-    suma = sum(w * int(c) for w, c in zip(wagi[len(cyfry)], cyfry))
-    return suma % 11 % 10 == int(cyfry[-1])
+    total = sum(w * int(c) for w, c in zip(weights[len(digits)], digits))
+    return total % 11 % 10 == int(digits[-1])
 
 
 def _nrb_valid(nrb: str) -> bool:
@@ -4478,8 +4493,8 @@ def _nrb_valid(nrb: str) -> bool:
     >>> _nrb_valid("17 1090 2851 0000 0001 3017 6425")
     False
     """
-    cyfry = re.sub(r"\s", "", nrb)
-    return len(cyfry) == 26 and cyfry.isdigit() and _iban_valid("PL" + cyfry)
+    digits = re.sub(r"\s", "", nrb)
+    return len(digits) == 26 and digits.isdigit() and _iban_valid("PL" + digits)
 
 
 #: Wzorce identyfikatorów rejestrowych i finansowych spotykanych w treści.
@@ -4522,23 +4537,23 @@ def registry_identifiers(text: str) -> list[tuple[str, str, str]]:
     [('NIP', '836-167-65-11', 'suma kontrolna **niepoprawna**')]
     """
     out: list[tuple[str, str, str]] = []
-    for etykieta, wzorzec, walidator in REGISTRY_PATTERNS:
-        for dopasowanie in dict.fromkeys(re.findall(wzorzec, text)):
-            if walidator is None:
+    for label, pattern, validator in REGISTRY_PATTERNS:
+        for matched in dict.fromkeys(re.findall(pattern, text)):
+            if validator is None:
                 status = "brak sumy kontrolnej w standardzie"
-            elif walidator(dopasowanie):
+            elif validator(matched):
                 status = (
                     "suma kontrolna poprawna (mod-97)"
-                    if "IBAN" in etykieta or "NRB" in etykieta
+                    if "IBAN" in label or "NRB" in label
                     else "suma kontrolna poprawna"
                 )
-            elif "IBAN" in etykieta or "NRB" in etykieta:
+            elif "IBAN" in label or "NRB" in label:
                 # Ciąg w kształcie IBAN-u z błędną sumą to inne ustalenie niż
                 # brak numeru — pomijanie go po cichu kasowałoby dowód.
                 status = "suma kontrolna **niepoprawna** (mod-97)"
             else:
                 status = "suma kontrolna **niepoprawna**"
-            out.append((etykieta, dopasowanie, status))
+            out.append((label, matched, status))
     return out
 
 
@@ -4567,36 +4582,34 @@ def identity_layers(
     """
     out: list[tuple[str, str]] = []
 
-    def dodaj(etykieta: str, wartosc: str | None) -> None:
-        if wartosc and (etykieta, wartosc) not in out:
-            out.append((etykieta, wartosc))
+    def add(label: str, value: str | None) -> None:
+        if value and (label, value) not in out:
+            out.append((label, value))
 
-    for naglowek, etykieta in (
+    for naglowek, label in (
         ("From", "Domena `From`"),
         ("Reply-To", "Domena `Reply-To`"),
         ("Return-Path", "Domena koperty (`Return-Path`)"),
         ("Sender", "Domena `Sender`"),
     ):
-        wartosc = msg.get(naglowek)
-        if not wartosc:
+        value = msg.get(naglowek)
+        if not value:
             continue
-        nazwa, adres = email.utils.parseaddr(str(wartosc))
+        name, adres = email.utils.parseaddr(str(value))
         if naglowek == "From":
-            dodaj("Nazwa wyświetlana `From`", nazwa.strip())
+            add("Nazwa wyświetlana `From`", name.strip())
         if adres and "@" in adres:
-            dodaj(etykieta, adres.rsplit("@", 1)[1].strip("> ").lower())
+            add(label, adres.rsplit("@", 1)[1].strip("> ").lower())
 
     for podpis in dkim:
-        dodaj("Domena podpisująca (DKIM `d=`)", podpis.domain)
+        add("Domena podpisująca (DKIM `d=`)", podpis.domain)
 
-    hosty_linkow = sorted(
-        {r.host.lower() for r in resources if r.kind == "a" and r.host}
-    )
-    if hosty_linkow:
-        dodaj("Hosty odnośników w treści", ", ".join(hosty_linkow))
-    hosty_zasobow = sorted(
+    link_hosts = sorted({r.host.lower() for r in resources if r.kind == "a" and r.host})
+    if link_hosts:
+        add("Hosty odnośników w treści", ", ".join(link_hosts))
+    resource_hosts = sorted(
         {r.host.lower() for r in resources if r.kind != "a" and r.host}
     )
-    if hosty_zasobow:
-        dodaj("Hosty zasobów pobieranych w treści", ", ".join(hosty_zasobow))
+    if resource_hosts:
+        add("Hosty zasobów pobieranych w treści", ", ".join(resource_hosts))
     return out

--- a/scripts/eml_forensics_logika.py
+++ b/scripts/eml_forensics_logika.py
@@ -1919,10 +1919,7 @@ def extract_attachments(tree: list[MimePart]) -> list[MimePart]:
     >>> extract_attachments(parts[:2])
     []
 
-    Exchange nadaje `Content-ID` samej części `text/html`, czyli ciału
-    wiadomości. Liczone jako część osadzona, ciało trafiało do tabeli pod
-    nagłówkiem „załączniki” i czytało się jak załącznik — a zdanie „brak
-    załączników” nie padało nigdzie, mimo że wiadomość ich nie ma:
+    `Content-ID` na części `text/html` to ciało wiadomości, nie załącznik:
 
     >>> body = MimePart(1, "text/html", "utf-8", "base64", None,
     ...                 "<AD821DA8@eurprd04.prod.outlook.com>", None, 10, "ab")
@@ -2345,8 +2342,7 @@ def find_hidden_elements(src: str) -> list[HiddenElement]:
     >>> find_hidden_elements('<div style="color:#000">jawne</div>')
     []
 
-    Biały tekst na zadeklarowanym kolorowym tle to element widoczny — oznaczanie
-    go jako ukrytego było fałszywym dowodem wytworzonym przez samo narzędzie:
+    Biały tekst na zadeklarowanym kolorowym tle to element widoczny:
 
     >>> find_hidden_elements(
     ...     '<div style="background-color:#1965F7;color:#FFFFFF">Zobacz cennik</div>')
@@ -2359,8 +2355,7 @@ def find_hidden_elements(src: str) -> list[HiddenElement]:
     ...     '<td id="stopka" style="color:#FFFFFF">Firma sp. z o.o.</td>')
     []
 
-    Ale tło zgodne z kolorem tekstu to nie brak ustalenia, tylko ustalenie
-    najmocniejsze — biały tekst na białym `body`:
+    Tło zgodne z kolorem tekstu to ustalenie najmocniejsze w tej klasie:
 
     >>> el = find_hidden_elements(
     ...     '<style>body{background-color:#ffffff}</style>'
@@ -2368,24 +2363,21 @@ def find_hidden_elements(src: str) -> list[HiddenElement]:
     >>> el.kind, "kolor tekstu identyczny z tłem (#ffffff)" in el.rules
     ('ukrywające', True)
 
-    Bez zadeklarowanego tła sam fakt białego tekstu zostaje odnotowany, ale
-    w klasie, która nie przesądza o widoczności:
+    Bez zadeklarowanego tła fakt zostaje odnotowany w klasie, która
+    o widoczności nie przesądza:
 
     >>> el = find_hidden_elements('<span style="color: white; font-size: 4px">x</span>')[0]
     >>> el.kind, el.rules, el.background is None
     ('kontrast/rozmiar', ('color:white', 'font-size:4px'), True)
 
-    Krycie nie zależy od tła, więc zadeklarowane tło go nie wyklucza — element
-    z `opacity:0.96` i własnym `background-color` znikał wcześniej z sekcji
-    w całości, razem z tekstem, który niósł:
+    Krycie nie zależy od tła, więc zadeklarowane tło go nie wyklucza:
 
     >>> el = find_hidden_elements(
     ...     '<div style="opacity:0.96;background-color:#1965F7;color:#FFFFFF">Zobacz</div>')[0]
     >>> el.kind, el.rules, el.text
     ('kontrast/rozmiar', ('opacity:0.96',), 'Zobacz')
 
-    Element pusty też jest ustaleniem — „nie znaleziono elementów z deklaracjami”
-    było nieprawdą przy pustym `<span>` z siedmioma takimi deklaracjami:
+    Element bez treści też jest ustaleniem:
 
     >>> el = find_hidden_elements('<span style="display:none;opacity:0"></span>')[0]
     >>> el.text, el.kind
@@ -2575,10 +2567,8 @@ def stylesheet_hiding_rules(src: str) -> list[StylesheetRule]:
     `<style>` były wcześniej usuwane z treści. Ustalenie „0 elementów” było więc
     prawdziwe tylko dla stylów inline — i nie mówiło o tym zakresie.
 
-    Reguła w `@media` obowiązuje **tylko** przy spełnionym warunku. Pominięcie
-    tego warunku zamieniało standardowy blok responsywny w „regułę usuwającą
-    element z widoku bez względu na kontekst renderowania” — czyli w dowód
-    ukrywania treści, którego plik nie zawiera:
+    Reguła w `@media` obowiązuje **tylko** przy spełnionym warunku — bez niego
+    blok responsywny czytałby się jak dowód ukrywania treści:
 
     >>> r = stylesheet_hiding_rules(
     ...     '<style>@media only screen and (max-width:714px){.hiddentds{display:none}}</style>'
@@ -2586,16 +2576,15 @@ def stylesheet_hiding_rules(src: str) -> list[StylesheetRule]:
     >>> r.selector, r.declarations, r.usage, r.condition
     ('.hiddentds', 'display:none', 1, '@media only screen and (max-width:714px)')
 
-    Reguła bezwarunkowa ma `condition` równe `None` — i tylko ona jest
-    samodzielnym ustaleniem o ukryciu:
+    Reguła bezwarunkowa ma `condition` równe `None` — tylko ona jest
+    samodzielnym ustaleniem:
 
     >>> r = stylesheet_hiding_rules(
     ...     '<style>.ukryte{display:none}</style><td class="ukryte">x</td>')[0]
     >>> r.condition is None, r.unconditional
     (True, True)
 
-    Atrybut bez cudzysłowów liczy się tak samo — wymaganie cudzysłowów dawało
-    licznik 0 przy siedemnastu elementach faktycznie noszących klasę:
+    Atrybut bez cudzysłowów liczy się tak samo:
 
     >>> r = stylesheet_hiding_rules(
     ...     '<STYLE>.hiddentds{display:none}</STYLE><TR class=hiddentds><TR class=hiddentds>')[0]
@@ -2790,16 +2779,13 @@ def extract_html_resources(src: str) -> list[HtmlResource]:
     >>> extract_html_resources('<html xmlns="http://www.w3.org/1999/xhtml">tresc</html>')
     []
 
-    Powtórzone odwołanie do tego samego URL-a jest jedną pozycją, ale z licznikiem
-    wystąpień — inaczej deduplikacja po cichu zaniżałaby liczbę znaczników:
+    Powtórzone odwołanie to jedna pozycja, ale z licznikiem wystąpień:
 
     >>> dwa = extract_html_resources('<a href="https://a.pl/x">raz</a><a href="https://a.pl/x">dwa</a>')
     >>> len(dwa), dwa[0].occurrences
     (1, 2)
 
-    Ten sam URL zapisany na dwa sposoby to **jeden** pobierany zasób. Liczenie
-    per zapis dawało „zasobów: 5” tam, gdzie pobierane są 3, i przeczyło
-    zdaniu „żadne odwołanie się nie powtarza” z tej samej sekcji:
+    Ten sam URL zapisany na dwa sposoby to **jeden** pobierany zasób:
 
     >>> jeden = extract_html_resources(
     ...     '<div style="width:1px;height:1px;background:url(https://t.pl/p.gif)"></div>')
@@ -3010,10 +2996,7 @@ def mixed_character_encodings(src: str) -> list[tuple[str, str, int, int]]:
     >>> mixed_character_encodings('<div dir="ltr">&quot;cytat&quot;</div>')
     []
 
-    Encje **numeryczne** liczą się tak samo jak nazwane. Pomijanie ich dawało
-    ustalenie negatywne „żaden znak nie występuje jednocześnie jako encja
-    i wprost” w wiadomości, w której zachodziło to dla każdego z sześciu
-    kodowanych znaków — i odwracało wymowę sekcji:
+    Encje **numeryczne** liczą się tak samo jak nazwane:
 
     >>> mixed_character_encodings("Maj&#99;hrowicz i c")
     [('c', '&#99;', 1, 2)]
@@ -3812,23 +3795,20 @@ def repeated_identifiers(
     ...     seeds=("aa/bb+cc=",), seed_only=frozenset({"DKIM", "ARC"}))
     [('aa/bb+cc=', ['DKIM', 'ARC'])]
 
-    UUID liczy się jako **jeden** identyfikator. Rozcinany na myślnikach dawał
-    cztery pozycje w tabeli, z których żadna nie jest identyfikatorem:
+    UUID liczy się jako **jeden** identyfikator, nie cztery fragmenty:
 
     >>> u = "9d1821a1-bdae-4c7b-9196-e7f1bf4deebd"
     >>> repeated_identifiers({"Message-ID": u, "link": f"https://a.pl/?c={u}"})
     [('9d1821a1-bdae-4c7b-9196-e7f1bf4deebd', ['Message-ID', 'link'])]
 
-    Etykieta domeny to nie identyfikator — powiązania nazw opisuje inwentarz
-    domen, a tabela korelatorów zapełniała się nimi w większości wierszy:
+    Etykieta domeny to nie identyfikator — nazwy opisuje inwentarz domen:
 
     >>> repeated_identifiers({"From": "a@newsletter.przyklad.pl",
     ...                       "Return-Path": "b@newsletter.przyklad.pl"})
     []
 
-    Identyfikator zadeklarowany w `List-Id` bywa wtopiony w adres zwrotny VERP
-    i w nazwę pliku piksela. Szukany jako całe słowo nie znajdował się nigdzie,
-    więc najsilniejszy korelator w wiadomości nie trafiał do tabeli:
+    Identyfikator z `List-Id` bywa wtopiony w VERP i w nazwę pliku piksela,
+    więc szukamy go jako podciągu:
 
     >>> repeated_identifiers(
     ...     {"List-Id": "<41634.z.przyklad.pl>",

--- a/scripts/eml_forensics_logika.py
+++ b/scripts/eml_forensics_logika.py
@@ -2917,11 +2917,11 @@ def classify_comments(src: str) -> list[HtmlComment]:
     []
     """
     out: list[HtmlComment] = []
-    for match in re.finditer(r"<!--.*?-->|<!\[endif\]-->", src, flags=re.DOTALL):
-        text = match.group(0)
-        before = src[max(0, match.start() - 1) : match.start()]
-        after = src[match.end() : match.end() + 1]
-        splits = bool(before and after and before[-1].isalnum() and after[0].isalnum())
+    # Pozycja w drzewie, nie w płaskim ciągu bajtów: sąsiedztwo komentarza
+    # czytamy z węzłów tekstowych obok niego, więc znacznik stojący pomiędzy
+    # nie udaje sąsiedniej litery. Treść komentarza bierzemy w całości —
+    # skan regexem obcinał ją do 120 znaków, gubiąc końcówkę dowodu.
+    for text, splits in _dom_comments(src):
         if re.search(r"\[if\b|\[endif\]", text, re.IGNORECASE):
             kind = "warunkowy MSO/Outlook"
         elif splits:
@@ -2935,11 +2935,44 @@ def classify_comments(src: str) -> list[HtmlComment]:
         else:
             kind = "zwykły"
         out.append(
-            HtmlComment(
-                text=re.sub(r"\s+", " ", text)[:120], kind=kind, splits_word=splits
-            )
+            HtmlComment(text=re.sub(r"\s+", " ", text), kind=kind, splits_word=splits)
         )
     return out
+
+
+def _dom_comments(src: str) -> list[tuple[str, bool]]:
+    """Komentarze z drzewa wraz z informacją, czy stoją wewnątrz wyrazu.
+
+    >>> _dom_comments('<p>Ka<!--x-->lenda</p>')
+    [('<!--x-->', True)]
+    >>> _dom_comments('<p>slowo <!--x--> drugie</p>')
+    [('<!--x-->', False)]
+    >>> _dom_comments('bez komentarzy')
+    []
+    """
+    found: list[tuple[str, bool]] = []
+
+    def visit(node: HtmlNode) -> None:
+        for index, item in enumerate(node.content):
+            if isinstance(item, DomComment):
+                previous = node.content[index - 1] if index else ""
+                following = (
+                    node.content[index + 1] if index + 1 < len(node.content) else ""
+                )
+                splits = bool(
+                    isinstance(previous, str)
+                    and isinstance(following, str)
+                    and previous
+                    and following
+                    and previous[-1].isalnum()
+                    and following[0].isalnum()
+                )
+                found.append((f"<!--{item.data}-->", splits))
+            elif isinstance(item, HtmlNode):
+                visit(item)
+
+    visit(parse_html(src))
+    return found
 
 
 def find_word_splitting_spans(src: str) -> list[str]:
@@ -2961,16 +2994,62 @@ def find_word_splitting_spans(src: str) -> list[str]:
     []
     """
     out: list[str] = []
-    for match in re.finditer(
-        r"<span[^>]*>.*?</span>", src, flags=re.DOTALL | re.IGNORECASE
-    ):
-        before = re.search(r"\w{0,12}$", src[: match.start()])
-        after = re.match(r"\w{0,12}", src[match.end() :])
-        left = before.group(0) if before else ""
-        right = after.group(0) if after else ""
-        if left and right:
-            out.append(left + match.group(0) + right)
+    # Sąsiedztwo czytane z drzewa, nie z płaskiego ciągu bajtów. Skan regexem
+    # brał za sąsiada dowolne znaki wokół dopasowania, także należące do innego
+    # znacznika, i nie umiał odróżnić `<span>` zamykającego się gdzie indziej.
+    for node, previous, following in _dom_inline_neighbours(src):
+        inner = "".join(c for c in node.content if isinstance(c, str))
+        # Odrzucamy WYŁĄCZNIE zawartość z odstępem na brzegu (także `&nbsp;`):
+        # `systemami<strong>&nbsp;CAM&nbsp;</strong>i` renderuje się z odstępami,
+        # więc wyrazu nie rozbija. Element PUSTY zostaje — `sło<span></span>wo`
+        # renderuje się jako `słowo`, a dla skanera jest dwoma fragmentami.
+        if inner and (inner[0].isspace() or inner[-1].isspace()):
+            continue
+        left = re.search(r"\w{0,12}$", previous)
+        right = re.match(r"\w{0,12}", following)
+        left_text = left.group(0) if left else ""
+        right_text = right.group(0) if right else ""
+        if left_text and right_text:
+            out.append(f"{left_text}<{node.tag}>{node.text()}</{node.tag}>{right_text}")
     return out
+
+
+#: Znaczniki liniowe: nie tworzą odstępu w renderze, więc stojąc w środku wyrazu
+#: rozbijają go dla filtru, a nie dla odbiorcy.
+INLINE_TAGS = frozenset(
+    ["span", "font", "strong", "b", "i", "em", "u", "small", "sub", "sup", "mark"]
+)
+
+
+def _dom_inline_neighbours(src: str) -> list[tuple[HtmlNode, str, str]]:
+    """Elementy liniowe wraz z tekstem bezpośrednio przed i po nich.
+
+    >>> [(n.tag, b, a) for n, b, a in _dom_inline_neighbours('<p>P<span>a</span>wo</p>')]
+    [('span', 'P', 'wo')]
+    >>> _dom_inline_neighbours('<p>bez elementow</p>')
+    []
+    """
+    found: list[tuple[HtmlNode, str, str]] = []
+
+    def visit(node: HtmlNode) -> None:
+        for index, item in enumerate(node.content):
+            if isinstance(item, HtmlNode):
+                if item.tag in INLINE_TAGS:
+                    previous = node.content[index - 1] if index else ""
+                    following = (
+                        node.content[index + 1] if index + 1 < len(node.content) else ""
+                    )
+                    found.append(
+                        (
+                            item,
+                            previous if isinstance(previous, str) else "",
+                            following if isinstance(following, str) else "",
+                        )
+                    )
+                visit(item)
+
+    visit(parse_html(src))
+    return found
 
 
 def _attr(attrs: str, name: str) -> str | None:

--- a/scripts/eml_forensics_logika.py
+++ b/scripts/eml_forensics_logika.py
@@ -28,6 +28,7 @@ import re
 import unicodedata
 import urllib.parse
 from dataclasses import dataclass, field, replace
+from html.parser import HTMLParser
 from pathlib import Path
 
 ZERO_WIDTH_CHARS = {
@@ -2324,6 +2325,179 @@ def text_blends_into_background(style: str, background: str | None) -> bool:
     return bool(text and background and text == background)
 
 
+#: Znaczniki blokowe — przy spłaszczaniu do tekstu wprowadzają odstęp.
+#: Znaczniki liniowe (`span`, `strong`, `a`) go NIE wprowadzają, bo render
+#: ich nie pokazuje. Bez tego rozróżnienia `RAM</STRONG><BR>Dysk` sklejało się
+#: w `RAMDysk`, a przy separatorze wszędzie — rozrywało wyrazy dzielone `<span>`.
+BLOCK_LEVEL_TAGS = frozenset(
+    [
+        "p",
+        "div",
+        "td",
+        "tr",
+        "table",
+        "br",
+        "li",
+        "ul",
+        "ol",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "blockquote",
+        "section",
+        "article",
+        "header",
+        "footer",
+        "hr",
+        "dd",
+        "dt",
+        "dl",
+        "pre",
+        "center",
+        "form",
+    ]
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DomComment:
+    """Komentarz HTML jako węzeł drzewa — dowód, ale nie element.
+
+    Osobny typ od `HtmlComment`, który niesie klasyfikację dla sekcji o
+    konstrukcjach; ten jest surowym węzłem z pozycją w drzewie.
+    """
+
+    data: str
+
+
+@dataclass
+class HtmlNode:
+    """Węzeł drzewa HTML: znacznik, atrybuty i uporządkowana zawartość.
+
+    `content` trzyma tekst, komentarze i dzieci **w kolejności dokumentu** —
+    bez tego nie da się stwierdzić, czy komentarz stoi między wyrazami, czy
+    rozbija wyraz w środku.
+    """
+
+    tag: str
+    attrs: dict[str, str] = field(default_factory=dict)
+    content: list = field(default_factory=list)
+
+    @property
+    def children(self) -> list["HtmlNode"]:
+        return [c for c in self.content if isinstance(c, HtmlNode)]
+
+    def text(self) -> str:
+        """Tekst elementu wraz z potomkami, z odstępem tylko na granicy bloku.
+
+        >>> parse_html('<div>ukryte <div>zagniezdzone</div> i dalej</div>').text()
+        'ukryte zagniezdzone i dalej'
+
+        Znaczniki liniowe nie tworzą odstępu, którego render nie pokazuje —
+        wyraz rozbity `<span>`-em składa się z powrotem:
+
+        >>> parse_html('<p>P<span>ańst</span>wo</p>').text()
+        'Państwo'
+
+        Znacznik blokowy odstęp tworzy:
+
+        >>> parse_html('<p>Pami\u0119\u0107 RAM<br>Dysk Twardy</p>').text()
+        'Pamięć RAM Dysk Twardy'
+
+        Komentarz nie jest treścią i nie tworzy odstępu:
+
+        >>> parse_html('<p>Ka<!--x-->lenda<!--x-->rzowy</p>').text()
+        'Kalendarzowy'
+        """
+        parts: list[str] = []
+        for item in self.content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, DomComment):
+                continue
+            else:
+                if item.tag in BLOCK_LEVEL_TAGS:
+                    parts.append(" ")
+                parts.append(item.text())
+                if item.tag in BLOCK_LEVEL_TAGS:
+                    parts.append(" ")
+        return re.sub(r"\s+", " ", "".join(parts)).strip()
+
+    def walk(self):
+        """Wszystkie węzły poddrzewa, w kolejności dokumentu."""
+        for child in self.children:
+            yield child
+            yield from child.walk()
+
+
+class _HtmlTreeParser(HTMLParser):
+    """Buduje drzewo `HtmlNode`. Komentarze nie stają się elementami."""
+
+    VOID = frozenset(
+        ["br", "img", "meta", "link", "hr", "input", "source", "area", "base", "col"]
+    )
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.root = HtmlNode("#root")
+        self.stack = [self.root]
+
+    def handle_starttag(self, tag, attrs):
+        node = HtmlNode(tag.lower(), {k.lower(): (v or "") for k, v in attrs})
+        self.stack[-1].content.append(node)
+        if tag.lower() not in self.VOID:
+            self.stack.append(node)
+
+    def handle_startendtag(self, tag, attrs):
+        self.stack[-1].content.append(
+            HtmlNode(tag.lower(), {k.lower(): (v or "") for k, v in attrs})
+        )
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+        for i in range(len(self.stack) - 1, 0, -1):
+            if self.stack[i].tag == tag:
+                del self.stack[i:]
+                return
+
+    def handle_data(self, data):
+        # BEZ strip(): białe znaki niosą dowód o tym, czy wyraz jest rozbity.
+        if data:
+            self.stack[-1].content.append(data)
+
+    def handle_comment(self, data):
+        self.stack[-1].content.append(DomComment(data))
+
+
+def parse_html(src: str) -> HtmlNode:
+    """Drzewo HTML zbudowane parserem, nie wyrażeniem regularnym.
+
+    Rozstrzyga trzy rzeczy, których skan regexem nie umie: granicę znacznika
+    przy `>` w wartości atrybutu, zasięg elementu przy zagnieżdżeniu tego
+    samego znacznika, i to, że komentarz nie jest elementem.
+
+    >>> parse_html('<div title="a > b">tresc</div>').children[0].text()
+    'tresc'
+    >>> parse_html('<div title="a > b">x</div>').children[0].attrs["title"]
+    'a > b'
+    >>> [n.tag for n in parse_html('<p>a<span>b</span></p>').walk()]
+    ['p', 'span']
+
+    `close()` jest obowiązkowe — bez niego parser zostawia ogon w buforze
+    i cicho gubi końcówkę dokumentu.
+
+    >>> parse_html('<p>tresc bez domkniecia').text()
+    'tresc bez domkniecia'
+    """
+    parser = _HtmlTreeParser()
+    parser.feed(src)
+    parser.close()
+    return parser.root
+
+
 def find_hidden_elements(src: str) -> list[HiddenElement]:
     """Elementy z deklaracjami CSS wpływającymi na widoczność, wraz z treścią.
 
@@ -2391,53 +2565,37 @@ def find_hidden_elements(src: str) -> list[HiddenElement]:
     []
     """
     out: list[HiddenElement] = []
-    # Komentarz HTML nie jest treścią dokumentu. Element z regułą ukrywającą
-    # zapisany WEWNĄTRZ komentarza był liczony jako ukryta treść — czyli dowód
-    # na coś, czego odbiorca nie dostał. Wygaszamy komentarze zachowując
-    # długość, żeby pozycje w `src` pozostały zgodne.
-    src = re.sub(r"<!--.*?-->", lambda m: " " * len(m.group(0)), src, flags=re.DOTALL)
-    # Skanujemy znaczniki OTWIERAJĄCE. Wzorzec wymagający pary `<tag>…</tag>`
-    # konsumował zagnieżdżone elementy i przy 27 komórkach `<TD>` z regułą
-    # ukrywającą raportował 9 — `finditer` nie zwraca dopasowań nakładających się.
-    pattern = re.compile(
-        r"<(?P<tag>div|span|p|td|tr|table|a|font)\b(?P<attrs>[^>]*)>",
-        re.IGNORECASE,
-    )
+    # Drzewo, nie skan regexem: rozstrzyga granicę znacznika przy `>` w wartości
+    # atrybutu, zasięg elementu przy zagnieżdżeniu tego samego znacznika,
+    # i to, że komentarz nie jest elementem. Wszystkie trzy dawały wcześniej
+    # albo urwany tekst dowodowy, albo element, którego w dokumencie nie ma.
     stylesheet = stylesheet_declarations(src)
-    for match in pattern.finditer(src):
-        style = _attr(match.group("attrs"), "style")
+    scanned = frozenset(["div", "span", "p", "td", "tr", "table", "a", "font"])
+    for node in parse_html(src).walk():
+        if node.tag not in scanned:
+            continue
+        style = node.attrs.get("style")
         if not style:
             continue
-        # Tło bierzemy najpierw z atrybutu elementu, a gdy go tam nie ma —
-        # z reguł `<style>` dopasowanych po `id`/`class`. Bez drugiego kroku
-        # biały tekst na czarnej stopce trafiał do sekcji o widoczności
-        # z adnotacją „tło nieustalone”, choć plik zawierał odpowiedź.
+        attrs = " ".join(f'{k}="{v}"' for k, v in node.attrs.items())
         background = declared_background(style) or background_for_element(
-            match.group("attrs"), stylesheet
+            attrs, stylesheet
         )
         hiding = _hidden_rules(style)
-        # Tło wyklucza regułę kontrastu tylko wtedy, gdy RÓŻNI SIĘ od koloru
-        # tekstu. Zgodność (biały na białym) jest odwrotnie — najmocniejszym
-        # przypadkiem w tej klasie, więc trafia do reguł ukrywających.
         blends = text_blends_into_background(style, background)
         if blends:
             hiding = hiding + [
                 f"kolor tekstu identyczny z tłem ({_colour(background)})"
             ]
         colour = [] if (background and not blends) else _color_contrast_rules(style)
-        # Krycie i rozmiar czcionki NIE zależą od tła, więc zadeklarowane tło
-        # ich nie wyklucza. Wspólne wykluczanie z kolorem tekstu kasowało cały
-        # element `opacity:0.96; background-color:#1965F7` — razem z jego treścią.
         low_contrast = colour + _dimming_rules(style)
         if not hiding and not low_contrast:
             continue
-        inner = html.unescape(re.sub(r"<[^>]+>", " ", _element_inner(src, match)))
-        inner = re.sub(r"\s+", " ", inner).strip()
         out.append(
             HiddenElement(
-                tag=match.group("tag").lower(),
+                tag=node.tag,
                 rules=tuple(hiding or low_contrast),
-                text=inner,
+                text=node.text(),
                 style=re.sub(r"\s+", " ", style).strip(),
                 kind="ukrywające" if hiding else "kontrast/rozmiar",
                 background=background,
@@ -3950,7 +4108,13 @@ def repeated_identifiers(
             for uuid_match in re.finditer(UUID_PATTERN, haystack, re.IGNORECASE):
                 note(uuid_match.group(0), label)
                 rest = rest.replace(uuid_match.group(0), " ")
-            for found in set(re.findall(rf"[A-Za-z0-9]{{{min_length},}}", rest)):
+            # `dict.fromkeys`, nie `set`: iteracja po zbiorze łańcuchów idzie
+            # w kolejności zależnej od losowania hashy, więc ten sam plik dawał
+            # raporty o różnej sumie kontrolnej między uruchomieniami. Dokument
+            # dowodowy musi być odtwarzalny co do bajtu.
+            for found in dict.fromkeys(
+                re.findall(rf"[A-Za-z0-9]{{{min_length},}}", rest)
+            ):
                 # Etykieta domeny (`newsletter`, `marketing`, `powiadomienia`)
                 # to nie identyfikator odbiorcy ani kampanii — powiązania między
                 # nazwami opisuje inwentarz domen. Skaner wpisywał je do tabeli

--- a/scripts/eml_forensics_raport.py
+++ b/scripts/eml_forensics_raport.py
@@ -310,20 +310,12 @@ def write_identification(
                     code(address.tag),
                 ]
             )
-    if rows:
-        write_table(
-            W,
-            [
-                "Nagłówek",
-                "Nazwa wyświetlana",
-                "Adres",
-                "Domena",
-                "Tag w części lokalnej",
-            ],
-            rows,
-        )
-    else:
-        write_no_findings(W, "Brak nagłówków adresowych.")
+    write_table_or_finding(
+        W,
+        ["Nagłówek", "Nazwa wyświetlana", "Adres", "Domena", "Tag w części lokalnej"],
+        rows,
+        "Brak nagłówków adresowych.",
+    )
 
     # Do tabeli trafiają WYŁĄCZNIE nagłówki, w których bajty z pliku różnią się
     # od wyniku parsera. Wcześniej wchodził tu także `Date` z identycznymi
@@ -2158,17 +2150,14 @@ def write_html_constructs_section(
         for part, body in parts
         for cp, count, name, note in unusual_characters(body)
     ]
-    if rows:
-        write_table(
-            W, ["Część", "Code point", "Liczba", "Nazwa Unicode", "Uwaga"], rows
-        )
-    else:
-        write_no_findings(
-            W,
-            "Brak znaków zerowej szerokości i homoglifów ASCII w "
-            + " i ".join(f"`{name}`" for name, _ in parts)
-            + ".",
-        )
+    write_table_or_finding(
+        W,
+        ["Część", "Code point", "Liczba", "Nazwa Unicode", "Uwaga"],
+        rows,
+        "Brak znaków zerowej szerokości i homoglifów ASCII w "
+        + " i ".join(f"`{name}`" for name, _ in parts)
+        + ".",
+    )
 
     W("\n### 18.4. Encje HTML\n")
     entities = numeric_entities(src)

--- a/scripts/eml_forensics_raport.py
+++ b/scripts/eml_forensics_raport.py
@@ -108,6 +108,62 @@ def write_no_findings(W: WriteLine, message: str) -> None:
     W(f"**Ustalenie negatywne:** {message}\n")
 
 
+def write_table_or_finding(
+    W: WriteLine,
+    headers: list[str],
+    rows: Iterable[list[str]],
+    empty_message: str,
+) -> int:
+    """Tabela, a gdy nie ma czego pokazać — ustalenie negatywne. Nigdy cisza.
+
+    Zdejmuje najczęstszy kształt w tym module: 42 wywołania `write_table`
+    i 63 `write_no_findings` to w większości ta sama para „są dane / nie ma
+    danych”, rozpisywana ręcznie przy każdej sekcji. Rozpisywana ręcznie
+    bywała też **niekompletna** — gałąź pusta gdzieniegdzie nie pisała nic,
+    więc czytelnik nie odróżniał „sprawdzone, brak” od „niesprawdzone”.
+
+    >>> lines = []
+    >>> write_table_or_finding(lines.append, ["A"], [["1"]], "Brak A.")
+    1
+    >>> lines[0]
+    '| A |'
+    >>> lines = []
+    >>> write_table_or_finding(lines.append, ["A"], [], "Brak A.")
+    0
+    >>> lines
+    ['**Ustalenie negatywne:** Brak A.\\n']
+    """
+    written = write_table(W, headers, rows)
+    if not written:
+        write_no_findings(W, empty_message)
+    return written
+
+
+def row(*cells: object) -> list[str]:
+    """Wiersz tabeli z `code()` nałożonym na każdą komórkę.
+
+    `code(...)` występuje w tym module **148 razy**, prawie zawsze w komórce
+    wiersza. Mapowanie po wierszu zamiast po komórce skraca wywołania i usuwa
+    klasę literówek, w której jedna komórka z pięciu zostawała bez `code()`.
+
+    >>> row("a", None, 7)
+    ['`a`', '—', '`7`']
+    """
+    return [code(c) for c in cells]
+
+
+def labelled_rows(pairs: Iterable[tuple[str, object]]) -> list[list[str]]:
+    """Wiersze „etykieta → wartość” z pominięciem pozycji bez wartości.
+
+    Kształt `[[etykieta, code(wartosc)] ...]` z filtrem `!= "—"` powtarza się
+    w tabelach tagów podpisów, pól skoku i cech pliku.
+
+    >>> labelled_rows([("`d=`", "a.pl"), ("`l=`", None)])
+    [['`d=`', '`a.pl`']]
+    """
+    return [[label, code(value)] for label, value in pairs if code(value) != "—"]
+
+
 def write_table(W: WriteLine, headers: list[str], rows: Iterable[list[str]]) -> int:
     """Tabela markdown bez pustych linii w środku — te łamały render w §2.5 i §6.5.
 
@@ -273,36 +329,36 @@ def write_identification(
     # od wyniku parsera. Wcześniej wchodził tu także `Date` z identycznymi
     # kolumnami, a pod spodem stało zdanie „wartości różnią się” — czytelnik
     # dostawał ustalenie o rozbieżności tam, gdzie rozbieżności nie ma.
-    porownania = [
-        (nazwa, doslownie, str(sparsowane))
-        for nazwa, doslownie, sparsowane in (literal_vs_parsed or ())
-        if doslownie and sparsowane and doslownie != str(sparsowane)
+    comparisons = [
+        (name, literal, str(sparsowane))
+        for name, literal, sparsowane in (literal_vs_parsed or ())
+        if literal and sparsowane and literal != str(sparsowane)
     ]
-    identyczne = [
-        nazwa
-        for nazwa, doslownie, sparsowane in (literal_vs_parsed or ())
-        if doslownie and sparsowane and doslownie == str(sparsowane)
+    identical_rows = [
+        name
+        for name, literal, sparsowane in (literal_vs_parsed or ())
+        if literal and sparsowane and literal == str(sparsowane)
     ]
-    if porownania:
+    if comparisons:
         write_table(
             W,
             ["Nagłówek", "Wartość dosłowna (bajty z pliku)", "Wartość po sparsowaniu"],
             [
-                [code(nazwa), code(doslownie), code(sparsowane)]
-                for nazwa, doslownie, sparsowane in porownania
+                row(name, literal, sparsowane)
+                for name, literal, sparsowane in comparisons
             ],
         )
         W(
             f"Nagłówków, w których bajty z pliku różnią się od wyniku parsera: "
-            f"**{len(porownania)}**. Przyczyną bywa kodowanie RFC 2047, zwinięcie "
+            f"**{len(comparisons)}**. Przyczyną bywa kodowanie RFC 2047, zwinięcie "
             f"na kilka linii albo normalizacja parsera (np. dopełnienie dnia zerem); "
             f"kolumna druga to bajty z pliku, trzecia to wynik parsera.\n"
         )
-    if identyczne:
+    if identical_rows:
         write_no_findings(
             W,
             "Bajty z pliku są identyczne z wynikiem parsera w nagłówkach: "
-            + ", ".join(code(n) for n in identyczne)
+            + ", ".join(code(n) for n in identical_rows)
             + " — nie ma tam kodowania ani zwinięcia.",
         )
 
@@ -476,7 +532,17 @@ def write_received_section(
     """
     W("## 3. Droga wiadomości (Received, od najstarszego)\n")
     if not hops:
+        # Wyjście z całej sekcji zabierało ze sobą inwentarz adresów, więc
+        # wiadomość bez `Received`, ale z `X-Originating-IP` albo `client-ip=`
+        # w `Received-SPF`, gubiła jedyny zapisany w pliku adres nadawcy.
         write_no_findings(W, "Brak nagłówków Received.")
+        if addresses:
+            W("\n**Adresy sieciowe występujące w wiadomości** (poza `Received`):\n")
+            write_table(
+                W,
+                ["Adres", "Rola", "Kategoria"],
+                [[code(a.value), escape_pipe(a.role), a.category] for a in addresses],
+            )
         W("")
         return
 
@@ -519,26 +585,26 @@ def write_received_section(
         # Wiersze puste są odfiltrowane, więc czytelnik nie odróżnia „pola nie
         # ma w nagłówku” od „parser go nie odczytał”. Dla pól, które niosą
         # dowód o pochodzeniu, mówimy to wprost.
-        brakujace = [
-            etykieta
-            for etykieta, wartosc in (
+        missing = [
+            label
+            for label, value in (
                 ("rDNS (nazwa odwrotna klienta)", hop.rdns),
                 ("HELO (nazwa zadeklarowana przez klienta)", hop.helo),
                 ("Znacznik czasu", hop.timestamp),
             )
-            if not wartosc
+            if not value
         ]
-        if brakujace:
+        if missing:
             write_no_findings(
                 W,
                 f"Skok {hop.index} nie zawiera pól: "
-                + ", ".join(f"**{e}**" for e in brakujace)
+                + ", ".join(f"**{e}**" for e in missing)
                 + ". Brak rDNS znaczy, że serwer przyjmujący nie ustalił nazwy "
                 "odwrotnej klienta albo jej nie zapisał.",
             )
 
-    ciaglosc = received_chain_continuity(hops)
-    if ciaglosc:
+    continuity = received_chain_continuity(hops)
+    if continuity:
         # Test ciągłości: host, który przyjął wiadomość (`by`), powinien być
         # tym, który ją dalej nadaje (`from`). Raport liczył skoki i orzekał
         # o poprawności składniowej nazw, ale tego zestawienia nie robił —
@@ -549,18 +615,18 @@ def write_received_section(
             ["Przejście", "`by` skoku N", "`from` skoku N+1", "Zgodne?"],
             [
                 [
-                    f"{numer} → {numer + 1}",
-                    code(odbiorca),
-                    code(nadawca),
-                    "tak" if zgodne else "**nie**",
+                    f"{number} → {number + 1}",
+                    code(receiver),
+                    code(sender),
+                    "tak" if matches else "**nie**",
                 ]
-                for numer, odbiorca, nadawca, zgodne in ciaglosc
+                for number, receiver, sender, matches in continuity
             ],
         )
-        przerwy = [c for c in ciaglosc if not c[3]]
-        if przerwy:
+        gaps = [c for c in continuity if not c[3]]
+        if gaps:
             W(
-                f"Przejść, w których nazwy się nie zgadzają: **{len(przerwy)}**. "
+                f"Przejść, w których nazwy się nie zgadzają: **{len(gaps)}**. "
                 f"Dla takiego odcinka plik nie zawiera nagłówka dokumentującego, "
                 f"jak wiadomość trafiła z jednego hosta na drugi.\n"
             )
@@ -598,25 +664,40 @@ def write_received_section(
     else:
         write_no_findings(W, "Nie znaleziono adresów IP w nagłówkach.")
 
-    conflicting = [
+    # Literał adresowy w HELO/EHLO ma być wg RFC 5321 §4.1.3 własnym adresem
+    # klienta. Sprawdzanie tego WYŁĄCZNIE w parze z ustalonym publicznym IP
+    # sprawiało, że skok deklarujący `helo=[127.0.0.1]` bez zapisanego adresu
+    # źródłowego nie dawał żadnego ustalenia — a deklaracja jest w pliku.
+    nonroutable_helo = [
         h
         for h in hops
         if h.helo
-        and h.ip
         and NetAddress.classify(h.helo.strip("[]"))
         not in {"nie jest adresem IP", "publiczny"}
-        and NetAddress.classify(h.ip) == "publiczny"
     ]
-    if conflicting:
-        W("\n**Skoki, w których klient zadeklarował w HELO adres nieroutowalny:**\n")
+    if nonroutable_helo:
+        W(
+            "\n**Skoki, w których klient zadeklarował w HELO adres nieroutowalny** "
+            "(RFC 5321 §4.1.3 wymaga, by literał w EHLO był własnym adresem "
+            "klienta):\n"
+        )
         write_table(
             W,
             [
                 "Skok",
                 "HELO (deklaracja klienta)",
+                "Kategoria adresu z HELO",
                 "Adres źródłowy ustalony przez serwer",
             ],
-            [[str(h.index), code(h.helo), code(h.ip)] for h in conflicting],
+            [
+                [
+                    str(h.index),
+                    code(h.helo),
+                    NetAddress.classify((h.helo or "").strip("[]")),
+                    code(h.ip) if h.ip else "brak w nagłówku",
+                ]
+                for h in nonroutable_helo
+            ],
         )
 
     invalid = invalid_hostnames(hops)
@@ -709,24 +790,22 @@ def write_timeline_section(
         # nie punkt doręczenia. Wciągnięte do rozpiętości dawało „12 h 30 min”
         # tam, gdzie wszystkie znaczniki doręczenia mieszczą się w 8 sekundach,
         # a tej ostatniej liczby raport nie podawał nigdzie.
-        zaszle = [(etykieta, dt) for etykieta, dt in ordered if "x=" not in etykieta]
-        if len(zaszle) > 1 and len(zaszle) != len(ordered):
-            faktyczna = (zaszle[-1][1] - zaszle[0][1]).total_seconds()
+        elapsed = [(label, dt) for label, dt in ordered if "x=" not in label]
+        if len(elapsed) > 1 and len(elapsed) != len(ordered):
+            actual = (elapsed[-1][1] - elapsed[0][1]).total_seconds()
             W(
                 f"Rozpiętość **po pominięciu znaczników wygaśnięcia `x=`** "
                 f"(to daty przyszłe wobec wysyłki, nie punkty doręczenia): "
-                f"**{format_duration(faktyczna)}**.\n"
+                f"**{format_duration(actual)}**.\n"
             )
         # Czas tranzytu liczony wyłącznie po `Received` — to jedyny odcinek,
         # który mówi o drodze wiadomości, a nie o momentach jej podpisania.
-        received = [
-            (etykieta, dt) for etykieta, dt in ordered if "Received" in etykieta
-        ]
+        received = [(label, dt) for label, dt in ordered if "Received" in label]
         if len(received) > 1:
-            tranzyt = (received[-1][1] - received[0][1]).total_seconds()
+            transit = (received[-1][1] - received[0][1]).total_seconds()
             W(
                 f"Czas tranzytu (od najstarszego do najnowszego `Received`): "
-                f"**{format_duration(tranzyt)}**, skoków ze znacznikiem: "
+                f"**{format_duration(transit)}**, skoków ze znacznikiem: "
                 f"**{len(received)}**.\n"
             )
 
@@ -871,28 +950,28 @@ def write_dkim_section(
             rows.append([f"`x=` ({sig.expires})", code(format_local(moment))])
         # Tagi spoza stałej listy (`v=`, `q=`, `b=`) są w pliku, a tabela ich
         # nie pokazywała — mimo że sekcja deklaruje wypisanie tagów podpisu.
-        rows += [[f"`{klucz}=`", code(wartosc)] for klucz, wartosc in sig.other_tags]
+        rows += [[f"`{klucz}=`", code(value)] for klucz, value in sig.other_tags]
         write_table(W, ["Tag", "Wartość"], [r for r in rows if r[1] != "—"])
         # Brak tagu to ustalenie tej samej klasy co jego obecność. Raport
         # odnotowywał wyłącznie brak `l=`, choć brak `t=` (podpis bez znacznika
         # czasu) i `x=` (bez daty wygaśnięcia) jest równie odczytywalny z pliku.
-        brakujace = [
-            etykieta
-            for etykieta, obecny in (
+        missing = [
+            label
+            for label, present in (
                 ("`t=` (znacznik czasu podpisu)", sig.timestamp),
                 ("`x=` (wygaśnięcie podpisu)", sig.expires),
                 ("`l=` (limit bajtów ciała)", sig.body_length),
             )
-            if not obecny
+            if not present
         ]
-        if brakujace:
+        if missing:
             write_no_findings(
                 W,
                 f"Sygnatura {i} nie zawiera tagów: "
-                + ", ".join(brakujace)
+                + ", ".join(missing)
                 + (
                     " — brak `l=` znaczy, że podpisem objęte jest całe ciało."
-                    if "`l=` (limit bajtów ciała)" in brakujace
+                    if "`l=` (limit bajtów ciała)" in missing
                     else ""
                 ),
             )
@@ -944,8 +1023,8 @@ def write_dkim_section(
             W,
             ["Powód odjęcia", "Nagłówki", "Liczba"],
             [
-                [powod, ", ".join(code(h) for h in nazwy), str(len(nazwy))]
-                for powod, nazwy in transit.items()
+                [reason, ", ".join(code(h) for h in names), str(len(names))]
+                for reason, names in transit.items()
             ],
         )
     W(
@@ -1003,21 +1082,19 @@ def write_arc_section(
             W,
             ["`i=`", "`d=`", "`s=`", "`cv=`", "`t=`"],
             [
-                [
-                    code(seal.index),
-                    code(seal.domain),
-                    code(seal.selector),
-                    code(seal.chain_validation),
-                    code(
-                        format_local(
-                            datetime.datetime.fromtimestamp(
-                                seal.timestamp, tz=datetime.timezone.utc
-                            )
+                row(
+                    seal.index,
+                    seal.domain,
+                    seal.selector,
+                    seal.chain_validation,
+                    format_local(
+                        datetime.datetime.fromtimestamp(
+                            seal.timestamp, tz=datetime.timezone.utc
                         )
-                        if seal.timestamp
-                        else None
-                    ),
-                ]
+                    )
+                    if seal.timestamp
+                    else None,
+                )
                 for seal in seals
             ],
         )
@@ -1057,7 +1134,7 @@ def write_arc_section(
                 ]
                 # Tagi spoza stałej listy — `fh=`, `dara=`, `b=`, `v=`, `q=` —
                 # są w pliku, a tabela ich nie pokazywała.
-                + [[f"`{klucz}=`", code(wartosc)] for klucz, wartosc in sig.other_tags],
+                + [[f"`{klucz}=`", code(value)] for klucz, value in sig.other_tags],
             )
             W(
                 f"Lista `h=` podpisu ARC nr {i} zapisuje, które nagłówki zostały "
@@ -1077,7 +1154,7 @@ def write_arc_section(
             # „to przez kanonizację” byłoby hipotezą podaną jako ustalenie —
             # w sekcji, której nagłówek deklaruje brak hipotez. Podajemy oba
             # `c=`, bo to fakty z pliku, i zostawiamy różnicę nierozstrzygniętą.
-            kanonizacje = sorted(
+            canonicalizations = sorted(
                 {
                     s.canonicalization
                     for s in list(signatures) + list(dkim)
@@ -1089,7 +1166,7 @@ def write_arc_section(
                 "DKIM. Raport **nie ustala przyczyny** — sprawdzenie wymagałoby "
                 "policzenia obu skrótów, czego raport nie robi (patrz zastrzeżenie "
                 "w sekcji o DKIM). Zadeklarowane kanonizacje `c=`: "
-                + (", ".join(code(k) for k in kanonizacje) or "brak")
+                + (", ".join(code(k) for k in canonicalizations) or "brak")
                 + ".\n"
             )
     else:
@@ -1159,7 +1236,7 @@ def write_dmarc_section(
             f"`{alignment.mailfrom_domain}` ≠ `{alignment.from_domain}`."
         )
     else:
-        brak = [
+        absent = [
             e
             for e, w in (
                 ("`From`", alignment.from_domain),
@@ -1169,7 +1246,7 @@ def write_dmarc_section(
         ]
         # Alternatywa „brak A albo B” czytała się jak stwierdzenie o pliku,
         # w którym `From` jest obecny — nazywamy więc konkretnie brakujące pole.
-        W(f"- Wyrównania SPF nie da się policzyć — w pliku brak: {', '.join(brak)}.")
+        W(f"- Wyrównania SPF nie da się policzyć — w pliku brak: {', '.join(absent)}.")
 
     if alignment.dkim_aligned is True:
         W(
@@ -1182,7 +1259,7 @@ def write_dmarc_section(
             "- **DKIM nie jest wyrównany** z `From` — żadna domena `d=` nie odpowiada domenie `From`."
         )
     else:
-        brak = [
+        absent = [
             e
             for e, w in (
                 ("`From`", alignment.from_domain),
@@ -1190,7 +1267,7 @@ def write_dmarc_section(
             )
             if not w
         ]
-        W(f"- Wyrównania DKIM nie da się policzyć — w pliku brak: {', '.join(brak)}.")
+        W(f"- Wyrównania DKIM nie da się policzyć — w pliku brak: {', '.join(absent)}.")
     W(
         "\nDomena organizacyjna liczona jako dwie ostatnie etykiety. Bez listy publicznych "
         "sufiksów (poza stdlib) to przybliżenie — obie domeny podano wyżej dosłownie.\n"
@@ -1388,12 +1465,12 @@ def write_list_headers_section(
     # sprawdzała jeden nagłówek z trzynastu, więc „brak kanału skargowego”,
     # „brak oznaczenia wiadomości jako automatycznej” i „brak identyfikatora
     # kampanii” nie padały nigdzie — mimo że są odczytywalne z pliku.
-    nieobecne = [n for n in LIST_HEADER_NAMES if n not in headers]
-    if nieobecne:
+    absent_headers = [n for n in LIST_HEADER_NAMES if n not in headers]
+    if absent_headers:
         write_no_findings(
             W,
             "Nagłówki nieobecne w wiadomości: "
-            + ", ".join(code(n) for n in nieobecne)
+            + ", ".join(code(n) for n in absent_headers)
             + ".",
         )
     if "List-Unsubscribe-Post" in headers:
@@ -1630,8 +1707,8 @@ def _token_result(token: Token) -> str:
     if token.byte_length == 0:
         # Brak wyniku opisujemy powodem, nie liczbą 0 — „0 B” czytało się jak
         # pusty ładunek, czyli jak ustalenie o zawartości tokenu.
-        powod = token.note or "nie zdekodowano"
-        return f"{powod} (skrót z ciągu: `{token.sha256_prefix}…`)"
+        reason = token.note or "nie zdekodowano"
+        return f"{reason} (skrót z ciągu: `{token.sha256_prefix}…`)"
     if token.note and token.note != "dane binarne":
         return token.note
     return f"dane binarne, {token.byte_length} B, sha256 `{token.sha256_prefix}…`"
@@ -1924,7 +2001,7 @@ def write_resources_section(resources: list[HtmlResource], W: WriteLine) -> None
         write_table(
             W,
             ["URL", "Atrybuty ze znacznika"],
-            [[code(p.url), code(p.attrs)] for p in pixels],
+            [row(p.url, p.attrs) for p in pixels],
         )
     else:
         write_no_findings(W, "Brak obrazów o zadeklarowanych wymiarach 1×1.")
@@ -1941,20 +2018,20 @@ def write_resources_section(resources: list[HtmlResource], W: WriteLine) -> None
     remote = [r for r in resources if r.scheme in {"http", "https"} and r.kind != "a"]
     relative = [r for r in resources if r.scheme == "względny"]
     if remote:
-        zapisow = sum(1 + len(r.also_as) for r in remote)
-        krotnosc = (
+        occurrence_count = sum(1 + len(r.also_as) for r in remote)
+        multiplicity = (
             ""
-            if zapisow == len(remote)
+            if occurrence_count == len(remote)
             else (
                 f" Ten sam URL bywa zapisany na kilka sposobów — zapisów w treści "
-                f"jest **{zapisow}**, pobieranych zasobów **{len(remote)}**."
+                f"jest **{occurrence_count}**, pobieranych zasobów **{len(remote)}**."
             )
         )
         W(
             f"Zasobów pobieranych z sieci po `http`/`https` (unikalnych URL-i): "
             f"**{len(remote)}** "
             f"(hosty: {', '.join(code(h) for h in sorted({r.host for r in remote if r.host}))})."
-            f"{krotnosc}\n"
+            f"{multiplicity}\n"
         )
     else:
         write_no_findings(
@@ -2115,18 +2192,18 @@ def write_html_constructs_section(
     # w `text/plain` to nie niespójność kodowania, tylko normalna konsekwencja
     # `multipart/alternative` — w części tekstowej encje HTML nie mają znaczenia.
     # Ustalenie ma dotyczyć jednego dokumentu, bo tylko tam jest obserwacją.
-    zakres = "część `text/html`"
+    scope = "część `text/html`"
     mixed = mixed_character_encodings(src)
     if text_body:
         mixed_plain = mixed_character_encodings(text_body)
         if mixed_plain and not mixed:
-            zakres = "część `text/plain`"
+            scope = "część `text/plain`"
             mixed = mixed_plain
         elif mixed_plain:
-            zakres = "każda część osobno"
+            scope = "każda część osobno"
             mixed = mixed + mixed_plain
     if mixed:
-        W(f"\nZnaki zapisane **dwoma sposobami naraz** (zakres: {zakres}):\n")
+        W(f"\nZnaki zapisane **dwoma sposobami naraz** (zakres: {scope}):\n")
         write_table(
             W,
             ["Znak", "Jako encja", "Wystąpień jako encja", "Wystąpień wprost"],
@@ -2139,7 +2216,7 @@ def write_html_constructs_section(
         write_no_findings(
             W,
             "Żaden znak nie występuje jednocześnie jako encja i wprost — sprawdzone: "
-            f"{zakres}.",
+            f"{scope}.",
         )
 
     W("\n### 18.5. Sklejenia na granicy znaczników liniowych\n")
@@ -2307,7 +2384,7 @@ def write_hidden_section(
             f"pominięte, tylko nie spełniają kryterium tej sekcji.",
         )
 
-    numer = itertools.count(1)
+    number = itertools.count(1)
     for label, group, note in (
         (
             "Deklaracje ukrywające (działają niezależnie od tła)",
@@ -2333,16 +2410,16 @@ def write_hidden_section(
         # Numer nadajemy dopiero przy druku — wcześniej pominięcie pustej grupy
         # zostawiało dziurę (19.1 → 19.3), która w dokumencie dowodowym sama
         # generuje pytanie „co wycięto”.
-        W(f"### 19.{next(numer)}. {label}\n")
+        W(f"### 19.{next(number)}. {label}\n")
         # Elementy BEZ treści (spacery układu) idą do jednej tabeli zbiorczej.
         # Rozpisane po jednej tabeli na sztukę zajmowały 22% raportu i przykryły
         # sobą błąd w regule `@media` leżący kilka linii niżej.
-        puste = [e for e in group if not e.text]
-        z_trescia = [e for e in group if e.text]
-        if puste:
+        empty = [e for e in group if not e.text]
+        with_text = [e for e in group if e.text]
+        if empty:
             W(
                 f"Elementów **bez treści tekstowej** (deklaracje obecne, nic nie "
-                f"ukrywają): **{len(puste)}** — zestawione zbiorczo:\n"
+                f"ukrywają): **{len(empty)}** — zestawione zbiorczo:\n"
             )
             write_table(
                 W,
@@ -2353,13 +2430,13 @@ def write_hidden_section(
                         ", ".join(code(r) for r in e.rules),
                         code(e.background),
                     ]
-                    for e in puste
+                    for e in empty
                 ],
             )
-        if not z_trescia:
+        if not with_text:
             W(f"{note}\n")
             continue
-        for i, element in enumerate(z_trescia, 1):
+        for i, element in enumerate(with_text, 1):
             W(f"**Element {i} — `<{element.tag}>`**\n")
             write_table(
                 W,
@@ -2445,12 +2522,12 @@ def write_content_section(
         # Procent liczony z sumy PODANYCH składników — wcześniej mianownikiem
         # była długość sprzed podziału, więc czytelnik nie odtwarzał liczby
         # z dwóch liczb wydrukowanych obok niej.
-        razem = len(own) + len(quoted)
+        combined = len(own) + len(quoted)
         W(
             f"Treść własna nadawcy: **{len(own)}** znaków "
             f"(**{len(re.sub(r'\s', '', own))}** niebędących białymi). "
             f"Cytat wcześniejszej korespondencji: **{len(quoted)}** znaków "
-            f"(**{100 * len(quoted) // max(1, razem)}%** sumy obu części).\n"
+            f"(**{100 * len(quoted) // max(1, combined)}%** sumy obu części).\n"
         )
         W("### Treść własna nadawcy\n")
         W("```")
@@ -2466,10 +2543,10 @@ def write_content_section(
         # liczba nie odtwarzała się z bloku stojącego pod nią. Zakończenia linii
         # są osobno raportowane w sekcji o sumach kontrolnych, więc normalizacja
         # tutaj nie kasuje dowodu.
-        drukowane = plain.replace("\r\n", "\n").replace("\r", "\n")
-        bez_bialych = len(re.sub(r"\s", "", drukowane))
+        printed = plain.replace("\r\n", "\n").replace("\r", "\n")
+        non_whitespace = len(re.sub(r"\s", "", printed))
         W(
-            f"Treść liczy **{len(drukowane)}** znaków, w tym **{bez_bialych}** "
+            f"Treść liczy **{len(printed)}** znaków, w tym **{non_whitespace}** "
             "niebędących białymi — obie liczby policzone na bloku poniżej, więc "
             "odtwarzają się z niego. Różnica to białe znaki: odstępy i złamania "
             "wierszy pozostałe po usunięciu znaczników. Zakończenia linii "
@@ -2477,7 +2554,7 @@ def write_content_section(
             "Nie wykryto granicy cytatu.\n"
         )
         W("```")
-        W(drukowane)
+        W(printed)
         W("```\n")
 
     W("### Porównanie części `text/plain` i `text/html`\n")
@@ -2498,9 +2575,9 @@ def write_content_section(
         f"zbiory słów, 0.0 = rozłączne). Porównywane są słowa, nie kolejność "
         f"ani formatowanie.\n"
     )
-    tylko_html = comparison.get("words_only_in_html") or []
-    tylko_text = comparison.get("words_only_in_text") or []
-    if tylko_html or tylko_text:
+    html_only = comparison.get("words_only_in_html") or []
+    text_only = comparison.get("words_only_in_text") or []
+    if html_only or text_only:
         W("Słowa występujące wyłącznie w jednej części:\n")
         write_table(
             W,
@@ -2510,13 +2587,13 @@ def write_content_section(
                 for w in (
                     [
                         "`text/html`",
-                        str(len(tylko_html)),
-                        ", ".join(code(x) for x in tylko_html[:40]) or "—",
+                        str(len(html_only)),
+                        ", ".join(code(x) for x in html_only[:40]) or "—",
                     ],
                     [
                         "`text/plain`",
-                        str(len(tylko_text)),
-                        ", ".join(code(x) for x in tylko_text[:40]) or "—",
+                        str(len(text_only)),
+                        ", ".join(code(x) for x in text_only[:40]) or "—",
                     ],
                 )
                 if w[1] != "0"
@@ -2626,17 +2703,17 @@ def write_artifacts_section(
     # Odstęp `Date` → `mtime`. Obie wartości były w raporcie (§4 i tu), różnicy
     # nie liczył nikt — mimo że sekcja o osi czasu liczy odstępy między każdą
     # parą znaczników. To jedyna liczba wiążąca wiadomość z kopią roboczą.
-    naglowek_daty = parse_date_header(str(date_header)) if date_header else None
-    if naglowek_daty:
+    date_value = parse_date_header(str(date_header)) if date_header else None
+    if date_value:
         try:
-            zapis = datetime.datetime.fromisoformat(file_mtime_iso)
+            written_at = datetime.datetime.fromisoformat(file_mtime_iso)
         except ValueError:
-            zapis = None
-        if zapis is not None and zapis.tzinfo is not None:
-            odstep = (zapis - naglowek_daty).total_seconds()
+            written_at = None
+        if written_at is not None and written_at.tzinfo is not None:
+            gap = (written_at - date_value).total_seconds()
             W(
-                f"\nOdstęp od `Date` wiadomości ({code(format_local(naglowek_daty))}) "
-                f"do `mtime` kopii roboczej: **{format_duration(odstep)}**. "
+                f"\nOdstęp od `Date` wiadomości ({code(format_local(date_value))}) "
+                f"do `mtime` kopii roboczej: **{format_duration(gap)}**. "
                 f"To odstęp do zapisu pliku w tym katalogu, nie do doręczenia.\n"
             )
     W(
@@ -2693,16 +2770,16 @@ def write_identity_layers_section(
         write_table(
             W,
             ["Warstwa", "Wartość zadeklarowana"],
-            [[etykieta, code(wartosc)] for etykieta, wartosc in layers],
+            [[label, code(value)] for label, value in layers],
         )
-        domeny = {w for e, w in layers if e.startswith("Domena") and "," not in w}
-        if len(domeny) > 1:
+        domains = {w for e, w in layers if e.startswith("Domena") and "," not in w}
+        if len(domains) > 1:
             # „Rejestrowalna” wymagałaby listy publicznych sufiksów, której nie
             # mamy w stdlib — `eu-west-1.amazonses.com` i `amazonses.com` to
             # jedna domena organizacyjna. Piszemy więc to, co faktycznie liczymy.
             W(
-                f"Różnych nazw w warstwach adresowych: **{len(domeny)}** "
-                f"({', '.join(code(d) for d in sorted(domeny))}). Liczone są "
+                f"Różnych nazw w warstwach adresowych: **{len(domains)}** "
+                f"({', '.join(code(d) for d in sorted(domains))}). Liczone są "
                 f"pełne nazwy hostów — bez listy publicznych sufiksów raport nie "
                 f"sprowadza ich do domeny organizacyjnej.\n"
             )
@@ -2714,7 +2791,7 @@ def write_identity_layers_section(
         write_table(
             W,
             ["Rodzaj", "Wartość z treści", "Suma kontrolna"],
-            [[rodzaj, code(wartosc), status] for rodzaj, wartosc, status in registry],
+            [[kind, code(value), status] for kind, value, status in registry],
         )
         W(
             "Suma kontrolna jest **policzona z wartości zapisanej w pliku** "

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -163,6 +163,11 @@ skip_sh() {
 skip_py() {
   case "$(basename "$1")" in
     utils.py|kontrola_logika.py|test_kontrola_logika.py|run_tests.py) return 0 ;;  # moduły/testy — run_tests.py jest CLI, ale odpala go osobny krok CI
+    # Warstwy eml_forensics: importowane przez eml_forensics.py, nie CLI.
+    # Wykluczenie było dopisane tylko w workflow (kontrola trybu pliku),
+    # a smoketest.sh próbuje URUCHOMIĆ każdy skrypt bezpośrednio — więc
+    # moduły bez +x wywracały build z „Permission denied”.
+    eml_forensics_logika.py|eml_forensics_raport.py|test_eml_forensics.py) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/test_eml_forensics.py
+++ b/scripts/test_eml_forensics.py
@@ -11,6 +11,7 @@ kodowania i strukturę nagłówków — bo to one wyzwalały błędy.
 """
 
 import datetime
+import os
 import re
 import sys
 import tempfile
@@ -1766,9 +1767,7 @@ class TestPokrycieUzupelniajace(unittest.TestCase):
 
     def test_wersja_uuid_jest_rozwinieta_w_sekcji_message_id(self):
         """Nibble wersji i wariantu to dane, nie ozdoba identyfikatora."""
-        raw = build(
-            "Message-ID: <3454bd31-1a2b-4c3d-8e4f-56789abcdef0@przyklad.pl>"
-        )
+        raw = build("Message-ID: <3454bd31-1a2b-4c3d-8e4f-56789abcdef0@przyklad.pl>")
         report = analyze(raw)
         self.assertIn("UUID", report)
         self.assertIn("wersja 4", report)
@@ -1803,6 +1802,47 @@ class TestPokrycieUzupelniajace(unittest.TestCase):
         """`X-CLIENT-IP` bywa jedynym zapisem adresu klienta."""
         report = analyze(build("X-Originating-IP: [198.51.100.7]"))
         self.assertIn("198.51.100.7", report)
+
+
+class TestOdtwarzalnosc(unittest.TestCase):
+    """Raport dowodowy musi być odtwarzalny co do bajtu."""
+
+    def test_raport_nie_zalezy_od_losowania_hashy(self):
+        """„Ten sam plik daje raporty o różnej sumie kontrolnej."
+
+        Iteracja po `set` łańcuchów idzie w kolejności zależnej od
+        `PYTHONHASHSEED`, więc kolejność wierszy w tabeli identyfikatorów
+        zmieniała się między uruchomieniami. Dwie osoby analizujące ten sam
+        plik dostawały dokumenty o różnych sumach kontrolnych.
+        """
+        import subprocess
+
+        raw = build(
+            "From: a@przyklad.pl\nReturn-Path: <bounce7f3a91c4@przyklad.pl>\n"
+            "List-Unsubscribe: <https://przyklad.pl/u/7f3a91c4/abcdef123456>\n"
+            "Message-ID: <abcdef123456@przyklad.pl>\n"
+            "Content-Type: text/html",
+            '<a href="https://przyklad.pl/r/7f3a91c4/x">t</a>',
+        )
+        checksums = set()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "w.eml"
+            path.write_bytes(raw.encode("utf-8"))
+            for seed in ("0", "1", "12345", "99991"):
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "scripts/eml_forensics.py",
+                        str(path),
+                        "--outdir",
+                        tmp,
+                    ],
+                    capture_output=True,
+                    env={**os.environ, "PYTHONHASHSEED": seed},
+                    check=True,
+                )
+                checksums.add((Path(tmp) / "w_analiza.md").read_bytes())
+        self.assertEqual(len(checksums), 1, "raport różni się między uruchomieniami")
 
 
 if __name__ == "__main__":

--- a/scripts/test_eml_forensics.py
+++ b/scripts/test_eml_forensics.py
@@ -12,6 +12,7 @@ kodowania i strukturę nagłówków — bo to one wyzwalały błędy.
 
 import datetime
 import re
+import sys
 import tempfile
 import unittest
 from email import message_from_string, policy
@@ -866,7 +867,7 @@ class TestRundaTrzecia(unittest.TestCase):
         html = '<img src="https://t.example/x" alt="" style="width:1px;height:1px;"/>'
         self.assertTrue(logika.extract_html_resources(html)[0].is_pixel)
 
-    def test_border_color_nie_jest_kolorem_tekstu(self):
+    def test_border_color_nie_jest_colourem_tekstu(self):
         """„Parser łapie po podciągu `color:` — w pliku są 2 takie border-top-color."""
         html = (
             '<table style="min-width:100%;border-top-width:2px;'
@@ -1224,7 +1225,7 @@ class TestRundaPiata(unittest.TestCase):
             1,
         )
 
-    def test_kanal_alfa_w_kolorze_jest_wykryty(self):
+    def test_kanal_alfa_w_colourze_jest_wykryty(self):
         """„#00000050 = czerń z kryciem 31% → renderuje się jako jasna szarość."""
         self.assertEqual(
             logika._low_contrast_rules("font-size:10px;color:#00000050"),
@@ -1561,6 +1562,247 @@ class TestRundaSzosta(unittest.TestCase):
         self.assertIn("indeks Jaccarda", report)
         self.assertIn("wyłącznie w jednej części", report)
         self.assertIn("delta", report)
+
+
+class TestPokrycieSciezekDowodowych(unittest.TestCase):
+    """Ścieżki niosące dowód, które nie miały ani jednego testu (pomiar coverage)."""
+
+    def test_rozne_bh_nie_dostaje_wyjasnienia_przyczyny(self):
+        """Raport nie policzył żadnego `bh=`, więc nie może podać, skąd różnica."""
+        raw = build(
+            "From: a@przyklad.pl\n"
+            "DKIM-Signature: v=1; d=przyklad.pl; s=s; h=From; c=relaxed/simple; bh=AAA=\n"
+            "ARC-Seal: i=1; d=posrednik.example; cv=none; t=1786107962\n"
+            "ARC-Message-Signature: i=1; d=posrednik.example; s=t; h=From;"
+            " c=relaxed/relaxed; bh=BBB="
+        )
+        report = analyze(raw)
+        self.assertIn("**różni się**", report)
+        self.assertIn("nie ustala przyczyny", report)
+        self.assertIn("relaxed/simple", report)
+        self.assertNotIn("to przez kanonizację", report)
+
+    def test_tekst_kotwicy_wygladajacy_na_adres_jest_zestawiony_z_celem(self):
+        """Tekst deklaruje jedną domenę, `href` prowadzi gdzie indziej."""
+        raw = build(
+            "Content-Type: text/html",
+            '<a href="https://cel.example/x?t=1">www.przyklad.pl</a>',
+        )
+        report = analyze(raw)
+        self.assertIn("Kotwice, w których tekst wyświetlany wygląda na adres", report)
+        self.assertIn("**nie**", report)
+
+    def test_sklejenia_na_granicy_znacznikow_sa_wypisane(self):
+        """Wyraz powstaje ze sklejenia dwóch elementów liniowych bez separatora."""
+        raw = build(
+            "Content-Type: text/html",
+            "<p><span>beda</span><strong>zawieszone</strong></p>",
+        )
+        report = analyze(raw)
+        self.assertIn("ze sklejenia dwóch sąsiednich", report)
+        self.assertIn("zawieszone", report)
+
+    def test_odwolania_po_http_sa_wypisane_z_osobna(self):
+        """Brak TLS przy pobieraniu zasobu to ustalenie o samym odwołaniu."""
+        raw = build("Content-Type: text/html", '<img src="http://cel.example/p.gif">')
+        report = analyze(raw)
+        self.assertIn("Odwołania po `http://` (bez TLS)", report)
+        self.assertIn("http://cel.example/p.gif", report)
+
+    def test_url_obecny_tylko_w_jednej_czesci_jest_nazwany(self):
+        """Rozjazd zbiorów URL-i między częściami to odrębne ustalenie."""
+        raw = (
+            'Content-Type: multipart/alternative; boundary="b"\n\n'
+            "--b\nContent-Type: text/plain\n\nbez linku\n"
+            "--b\nContent-Type: text/html\n\n"
+            '<a href="https://cel.example/tylko-html">x</a>\n--b--\n'
+        )
+        report = analyze(raw)
+        self.assertIn("URL-e obecne wyłącznie w `text/html`", report)
+        self.assertIn("https://cel.example/tylko-html", report)
+
+    def test_mieszany_zapis_wykryty_w_samej_czesci_tekstowej(self):
+        """Gdy niespójność jest tylko w `text/plain`, zakres ma to nazwać."""
+        raw = (
+            'Content-Type: multipart/alternative; boundary="b"\n\n'
+            "--b\nContent-Type: text/plain\n\nkt&oacute;ry i który\n"
+            "--b\nContent-Type: text/html\n\n<p>bez encji</p>\n--b--\n"
+        )
+        report = analyze(raw)
+        self.assertIn("część `text/plain`", report)
+
+    def test_helo_z_adresem_nieroutowalnym_jest_ustaleniem(self):
+        """`helo=[127.0.0.1]` — literał w EHLO ma być własnym adresem klienta."""
+        raw = build(
+            "Received: from klient.example (helo=[127.0.0.1]) by mx.example"
+            " with ESMTPSA; Tue, 11 Aug 2026 10:00:00 +0000"
+        )
+        report = analyze(raw)
+        self.assertIn("nieroutowalny", report)
+
+    def test_brak_in_reply_to_i_references_to_dwa_ustalenia(self):
+        """Wiadomość niepowiązana z wątkiem — obie nieobecności zapisane."""
+        report = analyze(build("From: a@przyklad.pl\nSubject: Bez watku"))
+        self.assertIn("Brak nagłówków `In-Reply-To` i `References`", report)
+
+    def test_uuid_spoza_rfc4122_jest_opisany(self):
+        """Nibble wersji poza 1–8 to inny fakt niż UUID nieznanej wersji."""
+        opis = logika.describe_uuid("3454bd31-1a2b-dc3d-ee4f-56789abcdef0")
+        self.assertIsNotNone(opis)
+        self.assertIn("spoza RFC 4122", opis)
+
+    def test_adres_z_klauzuli_by_trafia_do_inwentarza(self):
+        """Adres hosta przyjmującego jest daną o trasie, nie ozdobą."""
+        raw = build(
+            "Received: from a.example by mx.example ([203.0.113.9])"
+            " with ESMTP; Tue, 11 Aug 2026 10:00:00 +0000"
+        )
+        report = analyze(raw)
+        self.assertIn("203.0.113.9", report)
+
+    def test_client_ip_z_received_spf_trafia_do_inwentarza(self):
+        """`client-ip=` bywa jedynym zapisem adresu nadawcy w pliku."""
+        raw = build("Received-SPF: pass (przyklad.pl) client-ip=198.51.100.7;")
+        report = analyze(raw)
+        self.assertIn("198.51.100.7", report)
+
+    def test_epoka_ms_z_x_received_jest_punktem_osi(self):
+        """13-cyfrowa epoka w `X-Received` to niezależny znacznik czasu."""
+        raw = build("X-Received: by 2002:a05:1 with SMTP id x.1786107962148;")
+        report = analyze(raw)
+        self.assertIn("X-Received (epoka ms)", report)
+        self.assertIn("2026-08-07", report)
+
+    def test_vfill_odwoluje_sie_do_tego_samego_zasobu(self):
+        """VML `<v:fill src>` to ten sam zasób co tło CSS, innym zapisem."""
+        zasoby = logika.extract_html_resources(
+            '<v:fill src="https://cel.example/tlo.png" type="frame"/>'
+        )
+        self.assertEqual(zasoby[0].url, "https://cel.example/tlo.png")
+
+    def test_title_uzupelnia_tekst_kotwicy_i_obrazu(self):
+        """`title` bywa jedynym opisem, gdy tekst i `alt` są puste."""
+        a = logika.extract_html_resources(
+            '<a href="https://cel.example/x" title="Zobacz ofertę"></a>'
+        )[0]
+        self.assertIn("Zobacz ofertę", a.text)
+        img = logika.extract_html_resources(
+            '<img src="https://cel.example/i.png" alt="" title="Logo">'
+        )[0]
+        self.assertIn("Logo", img.text)
+
+    def test_mta_z_received_jest_sladem_oprogramowania(self):
+        """Nazwa MTA bywa jedyną identyfikacją oprogramowania w pliku."""
+        raw = build(
+            "Received: from a.example by mx.example (Postfix) with ESMTPA;"
+            " Tue, 11 Aug 2026 10:00:00 +0000"
+        )
+        report = analyze(raw)
+        self.assertIn("Postfix", report)
+
+    def test_komentarz_generatora_jest_sladem(self):
+        """`<!-- Created with ... -->` identyfikuje narzędzie wprost."""
+        raw = build("Content-Type: text/html", "<!-- Created with Edytor 2.0 -->x")
+        report = analyze(raw)
+        self.assertIn("Edytor 2.0", report)
+
+    def test_bledna_suma_kontrolna_iban_jest_ustaleniem(self):
+        """Ciąg w kształcie IBAN-u z błędną sumą to inne ustalenie niż brak numeru."""
+        wynik = logika.registry_identifiers("Konto: PL17109028510000000130176425")
+        self.assertEqual(len(wynik), 1)
+        self.assertIn("niepoprawna", wynik[0][2])
+
+    def test_hosty_zasobow_wchodza_do_warstw_tozsamosci(self):
+        """Host piksela bywa jedyną warstwą spoza domeny nadawcy."""
+        zasob = logika.HtmlResource(
+            "img", "https://cel.example/p.gif", None, "https", "cel.example"
+        )
+        warstwy = dict(
+            logika.identity_layers(
+                message_from_string("From: a@przyklad.pl\n\nx", policy=policy.default),
+                [],
+                [zasob],
+            )
+        )
+        self.assertEqual(warstwy["Hosty zasobów pobieranych w treści"], "cel.example")
+
+    def test_cli_konczy_sie_bledem_gdy_brak_pliku(self):
+        """Ścieżka CLI też jest kodem — brak pliku ma dawać kontrolowany błąd."""
+        import subprocess
+
+        wynik = subprocess.run(
+            [sys.executable, "scripts/eml_forensics.py", "/nie/ma/takiego.eml"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(wynik.returncode, 0)
+
+
+class TestPokrycieUzupelniajace(unittest.TestCase):
+    """Reszta ścieżek bez pokrycia — każda niesie ustalenie o pliku."""
+
+    def test_wiadomosc_bez_czesci_mime(self):
+        """Plik bez ciała to też stan do zapisania, nie pusty raport."""
+        report = analyze("From: a@przyklad.pl\nSubject: Puste\n\n")
+        self.assertIn("## 2.", report)
+
+    def test_kilka_zalacznikow_z_identyczna_trescia(self):
+        """Bajtowo identyczne załączniki to fakt o sposobie złożenia wiadomości."""
+        czesc = (
+            "--b\nContent-Type: image/png\nContent-Transfer-Encoding: base64\n"
+            'Content-Disposition: attachment; filename="{}"\n\naGVsbG8=\n'
+        )
+        raw = (
+            'Content-Type: multipart/mixed; boundary="b"\n\n'
+            "--b\nContent-Type: text/html\n\n<p>x</p>\n"
+            + czesc.format("a.png")
+            + czesc.format("b.png")
+            + "--b--\n"
+        )
+        report = analyze(raw)
+        self.assertIn("a.png", report)
+        self.assertIn("b.png", report)
+
+    def test_wersja_uuid_jest_rozwinieta_w_sekcji_message_id(self):
+        """Nibble wersji i wariantu to dane, nie ozdoba identyfikatora."""
+        raw = build(
+            "Message-ID: <3454bd31-1a2b-4c3d-8e4f-56789abcdef0@przyklad.pl>"
+        )
+        report = analyze(raw)
+        self.assertIn("UUID", report)
+        self.assertIn("wersja 4", report)
+
+    def test_url_wylacznie_w_czesci_tekstowej(self):
+        """Rozjazd w drugą stronę: adres jest w `text/plain`, nie ma go w HTML."""
+        raw = (
+            'Content-Type: multipart/alternative; boundary="b"\n\n'
+            "--b\nContent-Type: text/plain\n\nhttps://cel.example/tylko-plain\n"
+            "--b\nContent-Type: text/html\n\n<p>bez linku</p>\n--b--\n"
+        )
+        report = analyze(raw)
+        self.assertIn("URL-e obecne wyłącznie w `text/plain`", report)
+
+    def test_brak_samego_in_reply_to_przy_obecnym_references(self):
+        """Dwa nagłówki wątku są niezależne — nieobecność każdego to osobny fakt."""
+        raw = build("References: <a@przyklad.pl>\nSubject: Re: Temat")
+        report = analyze(raw)
+        self.assertIn("Brak nagłówka `In-Reply-To`", report)
+
+    def test_parametr_sendgrid_jest_odescapowany(self):
+        """`-2B`/`-2F`/`-3D` w URL-u to kodowanie dostawcy, nie treść tokenu."""
+        tokeny = logika.decode_tokens(
+            "https://cel.example/wf/open?upn=YWJjZGVmZ2hpams-3D"
+        )
+        self.assertTrue(
+            any("odescapowaniu" in t.source for t in tokeny),
+            [t.source for t in tokeny],
+        )
+
+    def test_adres_ipv4_z_dowolnego_naglowka_x(self):
+        """`X-CLIENT-IP` bywa jedynym zapisem adresu klienta."""
+        report = analyze(build("X-Originating-IP: [198.51.100.7]"))
+        self.assertIn("198.51.100.7", report)
 
 
 if __name__ == "__main__":

--- a/scripts/test_eml_forensics.py
+++ b/scripts/test_eml_forensics.py
@@ -20,6 +20,11 @@ from email import message_from_string, policy
 from pathlib import Path
 
 import eml_forensics
+
+#: Ścieżka do CLI liczona od tego pliku, nie od katalogu roboczego —
+#: test uruchamiany spoza repo szedł na nieistniejącą ścieżkę i „przechodził”
+#: dlatego, że skryptu nie było, a nie dlatego, że zachowanie jest poprawne.
+CLI = Path(__file__).resolve().parent / "eml_forensics.py"
 import eml_forensics_logika as logika
 import eml_forensics_raport as raport
 
@@ -1732,7 +1737,7 @@ class TestPokrycieSciezekDowodowych(unittest.TestCase):
         import subprocess
 
         wynik = subprocess.run(
-            [sys.executable, "scripts/eml_forensics.py", "/nie/ma/takiego.eml"],
+            [sys.executable, str(CLI), "/nie/ma/takiego.eml"],
             capture_output=True,
             text=True,
             check=False,
@@ -1830,13 +1835,7 @@ class TestOdtwarzalnosc(unittest.TestCase):
             path.write_bytes(raw.encode("utf-8"))
             for seed in ("0", "1", "12345", "99991"):
                 subprocess.run(
-                    [
-                        sys.executable,
-                        "scripts/eml_forensics.py",
-                        str(path),
-                        "--outdir",
-                        tmp,
-                    ],
+                    [sys.executable, str(CLI), str(path), "--outdir", tmp],
                     capture_output=True,
                     env={**os.environ, "PYTHONHASHSEED": seed},
                     check=True,


### PR DESCRIPTION
Smoketest po poprzednim commicie wywraca się na trzech plikach:

```
✗ BRAK +x  eml_forensics_logika.py  (exit=126)
✗ BRAK +x  eml_forensics_raport.py  (exit=126)
✗ BRAK +x  test_eml_forensics.py    (exit=126)
```

## Przyczyna

Są **dwie niezależne warstwy** kontroli bitu `+x`, a wyjątek dopisałem tylko do jednej:

| Warstwa | Co robi | Wyjątek był? |
|---|---|---|
| `.github/workflows/smoketest.yml` | sprawdza **tryb pliku** (`git ls-files -s` = `100755`) | ✅ tak |
| `scripts/smoketest.sh` → `skip_py` | **uruchamia** każdy skrypt bezpośrednio (`./skrypt`) | ❌ nie |

Te trzy pliki celowo nie mają `+x` — nie są CLI, tylko warstwami importowanymi przez `eml_forensics.py`. Nadanie im `+x` byłoby nieprawdziwą deklaracją o ich roli, więc poprawką jest wyjątek, nie `chmod`.

## Poprawka

Dopisanie ich do `skip_py` w `scripts/smoketest.sh`, obok istniejących modułów (`utils.py`, `kontrola_logika.py`, `test_kontrola_logika.py`).

## Weryfikacja

Lokalnie `bash scripts/smoketest.sh scripts`:

```
✓ syntax eml_forensics_logika.py
✓ ok     eml_forensics_logika.py (bez argumentów, python3)  (exit=0)
✓ ok     eml_forensics.py  (exit=0)
Smoketest: OK
```

Zero wystąpień `BRAK +x`. Testy bez zmian: **343** przechodzą.