### PR TITLE
chore(scripts): ruff check czysty, doctesty, testy manifest.py

### DIFF
--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -29,8 +29,9 @@ jobs:
           for f in $(git ls-files 'scripts/*.sh' 'scripts/*.py'); do
             case "$(basename "$f")" in
               # celowo bez +x: nie do bezpośredniego uruchamiania (source/import, nie CLI)
-              lib.sh|utils.py|kontrola_logika.py|test_kontrola_logika.py) continue ;;
-              eml_forensics_logika.py|eml_forensics_raport.py|test_eml_forensics.py) continue ;;
+              lib.sh|utils.py|kontrola_logika.py) continue ;;
+              eml_forensics_logika.py|eml_forensics_raport.py) continue ;;
+              test_*.py) continue ;;
             esac
             mode=$(git ls-files -s "$f" | awk '{print $1}')
             if [ "$mode" != "100755" ]; then

--- a/scripts/build_pismo.py
+++ b/scripts/build_pismo.py
@@ -64,7 +64,8 @@ def find_chrome():
 
 def render_md(path):
     if not shutil.which("pandoc"):
-        return "<pre>" + H.escape(open(path, encoding="utf-8").read()) + "</pre>"
+        with open(path, encoding="utf-8") as f:
+            return "<pre>" + H.escape(f.read()) + "</pre>"
     out = subprocess.run(
         ["pandoc", "-f", "markdown", "-t", "html5", path],
         capture_output=True,
@@ -93,14 +94,12 @@ def render_attachment(path):
         import mimetypes
 
         mt = mimetypes.guess_type(path)[0] or "image/png"
-        b64 = base64.b64encode(open(path, "rb").read()).decode()
+        with open(path, "rb") as f:
+            b64 = base64.b64encode(f.read()).decode()
         return f'<img src="data:{mt};base64,{b64}" style="max-width:100%">'
     if ext in PRE_EXT or ext == ".html":
-        return (
-            "<pre>"
-            + H.escape(open(path, encoding="utf-8", errors="replace").read())
-            + "</pre>"
-        )
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return "<pre>" + H.escape(f.read()) + "</pre>"
     return (
         f"<p><i>Załącznik w postaci pliku binarnego <code>{H.escape(os.path.basename(path))}</code> "
         f"({human(os.path.getsize(path))}) — dołączony osobno w <code>dowody.zip</code>. "
@@ -123,7 +122,8 @@ def main():
     ap.add_argument("--keep-html", action="store_true")
     a = ap.parse_args()
 
-    tpl = open(a.szablon, encoding="utf-8").read()
+    with open(a.szablon, encoding="utf-8") as f:
+        tpl = f.read()
 
     blocks, lista, zal_info = [], [], []
     for i, spec in enumerate(a.zalacznik, 1):
@@ -151,7 +151,8 @@ def main():
     )
 
     tmp = a.out + ".build.html"
-    open(tmp, "w", encoding="utf-8").write(tpl)
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(tpl)
 
     chrome = find_chrome()
     if shutil.which("weasyprint"):
@@ -171,7 +172,7 @@ def main():
             "--virtual-time-budget=20000",
             f"file://{os.path.abspath(tmp)}",
         ]
-        r = subprocess.run(cmd, capture_output=True, text=True)
+        r = subprocess.run(cmd, capture_output=True, text=True, check=False)
         if r.returncode != 0 or not os.path.exists(a.out):
             sys.exit("Chrome/Chromium headless: " + (r.stderr or "")[-800:])
     elif shutil.which("wkhtmltopdf"):
@@ -207,7 +208,7 @@ def main():
             tmp,
             a.out,
         ]
-        r = subprocess.run(cmd, capture_output=True, text=True)
+        r = subprocess.run(cmd, capture_output=True, text=True, check=False)
         if r.returncode != 0:
             sys.exit("wkhtmltopdf: " + (r.stderr or "")[-800:])
     else:
@@ -229,7 +230,9 @@ def main():
     if shutil.which("pdfinfo"):
         m = re.search(
             r"Pages:\s+(\d+)",
-            subprocess.run(["pdfinfo", a.out], capture_output=True, text=True).stdout,
+            subprocess.run(
+                ["pdfinfo", a.out], capture_output=True, text=True, check=False
+            ).stdout,
         )
         if m:
             pages = m.group(1)
@@ -263,7 +266,9 @@ def main():
         )
         ok &= kartek <= 98
     if shutil.which("pdffonts"):
-        out = subprocess.run(["pdffonts", a.out], capture_output=True, text=True).stdout
+        out = subprocess.run(
+            ["pdffonts", a.out], capture_output=True, text=True, check=False
+        ).stdout
         lines = out.splitlines()
         # kolumny mają stałą szerokość; "type" bywa dwuwyrazowe ("CID TrueType"),
         # więc pozycję kolumny emb bierzemy z nagłówka, nie ze split()

--- a/scripts/dane_nadawcy_status.py
+++ b/scripts/dane_nadawcy_status.py
@@ -108,7 +108,7 @@ def znajdz(wartosci: dict[str, str], pole: str) -> str:
     if pole in wartosci:
         return wartosci[pole]
     for k, v in wartosci.items():
-        if k == pole or k.startswith(pole + " ") or k.startswith(pole + "("):
+        if k == pole or k.startswith((pole + " ", pole + "(")):
             return v
     return ""
 
@@ -118,7 +118,8 @@ def main():
         sys.exit("Użycie: dane_nadawcy_status.py <plik>")
 
     try:
-        text = open(sys.argv[1], encoding="utf-8").read()
+        with open(sys.argv[1], encoding="utf-8") as f:
+            text = f.read()
     except FileNotFoundError:
         for pole in KRYTYCZNE:
             print(f"BRAK {pole}")

--- a/scripts/eml_forensics_logika.py
+++ b/scripts/eml_forensics_logika.py
@@ -2145,7 +2145,13 @@ LOW_CONTRAST_DECLARATIONS = COLOR_CONTRAST_DECLARATIONS + DIMMING_DECLARATIONS
 
 
 def _match_declarations(style: str, patterns: tuple[str, ...]) -> list[str]:
-    """Dopasowane deklaracje CSS, zwrócone dosłownie w kolejności wzorców."""
+    """Dopasowane deklaracje CSS, zwrócone dosłownie w kolejności wzorców.
+
+    >>> _match_declarations("color: RED; opacity:0.5", (r"color:\\w+", r"opacity:0\\.\\d+"))
+    ['color:red', 'opacity:0.5']
+    >>> _match_declarations("display:block", (r"display:none",))
+    []
+    """
     normalized = re.sub(r"\s*:\s*", ":", style.lower())
     found = []
     for pattern in patterns:
@@ -2792,7 +2798,13 @@ def _rules_with_conditions(block: str) -> list[tuple[str, str, str | None]]:
 def _rules_in(
     block: str, conditions: tuple[str, ...]
 ) -> list[tuple[str, str, str | None]]:
-    """Rekurencyjny krok `_rules_with_conditions`, ze stosem warunków."""
+    """Rekurencyjny krok `_rules_with_conditions`, ze stosem warunków.
+
+    >>> _rules_in(".a{display:none}", ())
+    [('.a', 'display:none', None)]
+    >>> _rules_in("@media (max-width:600px){.b{color:red}}", ())
+    [('.b', 'color:red', '@media (max-width:600px)')]
+    """
     scan = _blank_css_noise(block)
     readable = _blank_css_noise(block, strings=False)
     out: list[tuple[str, str, str | None]] = []

--- a/scripts/kontrola_logika.py
+++ b/scripts/kontrola_logika.py
@@ -3,8 +3,8 @@
 Bez I/O, bez subprocesów — wejście: tekst, wyjście: wynik. Testowalność bez PDF.
 """
 
-import re
 import collections
+import re
 
 # Polskie cudzysłowy i angielskie — maskujemy cytaty, żeby nie wykryć nawiasów w cytatach
 _QUOTE_RE = re.compile(r"[\u201e\u201c\"][^\u201d\u201c\"]{0,400}[\u201d\u201c\"]")
@@ -65,7 +65,7 @@ def find_attachment_page_headers(t: str) -> list:
     >>> find_attachment_page_headers("Załącznik nr 1 — Umowa\\nZałącznik nr 2 — Faktura")
     [('1', 'Umowa'), ('2', 'Faktura')]
     """
-    return re.findall(r"Za[łl][ąa]cznik\s+nr\s+(\d+)\s*[—–-]\s*(.+)", t, re.I)
+    return re.findall(r"Za[łl][ąa]cznik\s+nr\s+(\d+)\s*[—–-]\s*(.+)", t, re.IGNORECASE)
 
 
 def find_attachment_list_items(t: str) -> list:
@@ -78,7 +78,7 @@ def find_attachment_list_items(t: str) -> list:
     >>> find_attachment_list_items("Załącznik nr 1: Umowa\\nZałącznik nr 2: Faktura")
     [('1', 'Umowa'), ('2', 'Faktura')]
     """
-    return re.findall(r"Za[łl][ąa]cznik\s+nr\s+(\d+):\s*(.+)", t, re.I)
+    return re.findall(r"Za[łl][ąa]cznik\s+nr\s+(\d+):\s*(.+)", t, re.IGNORECASE)
 
 
 def find_cross_references(t: str) -> set:
@@ -93,11 +93,11 @@ def find_cross_references(t: str) -> set:
     >>> find_cross_references("zał. 1 i zał. 1")
     {1}
     """
-    refs = {int(x) for x in re.findall(r"zał\.\s*(\d+)", t, re.I)}
+    refs = {int(x) for x in re.findall(r"zał\.\s*(\d+)", t, re.IGNORECASE)}
     refs |= {
         int(x)
         for x in re.findall(
-            r"za[łl][ąa]cznik(?:a|iem|u|ach|ow|ów)?\s+nr\s*(\d+)", t, re.I
+            r"za[łl][ąa]cznik(?:a|iem|u|ach|ow|ów)?\s+nr\s*(\d+)", t, re.IGNORECASE
         )
     }
     return refs
@@ -165,7 +165,8 @@ def find_paragraph_numbering_issues(t: str) -> tuple:
     ([], [])
     """
     ust = [
-        int(m.group(1)) for m in re.finditer(r"^\s{0,8}(\d{1,3})\.\s{2,}\S", t, re.M)
+        int(m.group(1))
+        for m in re.finditer(r"^\s{0,8}(\d{1,3})\.\s{2,}\S", t, re.MULTILINE)
     ]
     if not ust:
         return [], []

--- a/scripts/kontrola_pisma.py
+++ b/scripts/kontrola_pisma.py
@@ -19,18 +19,25 @@ Użycie:
 Kod wyjścia: 0 = brak błędów blokujących, 1 = są błędy.
 """
 
-import argparse, os, re, subprocess, sys, shutil, zipfile
-from utils import sha256_file as sha
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import zipfile
+
 from kontrola_logika import (
-    find_placeholders,
-    find_attachment_page_headers,
     find_attachment_list_items,
+    find_attachment_page_headers,
     find_cross_references,
     find_numbering_gaps_and_duplicates,
-    titles_match,
     find_paragraph_numbering_issues,
+    find_placeholders,
     find_sha256_hashes,
+    titles_match,
 )
+from utils import sha256_file as sha
 
 
 def tekst_pdf(p):
@@ -39,7 +46,7 @@ def tekst_pdf(p):
             "BŁĄD: brak pdftotext (pakiet poppler-utils) — nie da się skontrolować pisma."
         )
     return subprocess.run(
-        ["pdftotext", "-layout", p, "-"], capture_output=True, text=True
+        ["pdftotext", "-layout", p, "-"], capture_output=True, text=True, check=False
     ).stdout
 
 
@@ -72,7 +79,8 @@ def main():
 
     # ---- 1. niewypełnione pola --------------------------------------------
     if a.html and os.path.exists(a.html):
-        h = re.sub(r"<!--.*?-->", "", open(a.html, encoding="utf-8").read(), flags=re.S)
+        with open(a.html, encoding="utf-8") as f:
+            h = re.sub(r"<!--.*?-->", "", f.read(), flags=re.DOTALL)
         fill = [
             x.strip()
             for x in re.findall(r'class="fill[^"]*"[^>]*>([^<]{0,120})', h)
@@ -163,7 +171,7 @@ def main():
                 nazwy = [n for n in z.namelist() if not n.endswith("/")]
             if not nazwy:
                 b("dowody.zip jest pusty")
-            zle = z_test = None
+            z_test = None
             with zipfile.ZipFile(a.zip) as z:
                 z_test = z.testzip()
             if z_test:
@@ -191,14 +199,18 @@ def main():
     if shutil.which("pdfinfo"):
         m = re.search(
             r"Pages:\s+(\d+)",
-            subprocess.run(["pdfinfo", a.pdf], capture_output=True, text=True).stdout,
+            subprocess.run(
+                ["pdfinfo", a.pdf], capture_output=True, text=True, check=False
+            ).stdout,
         )
         if m and (int(m.group(1)) + 1) // 2 > 98:
             b(
                 f"{m.group(1)} stron = {(int(m.group(1)) + 1) // 2} kartek — limit to 98 kartek"
             )
     if shutil.which("pdffonts"):
-        out = subprocess.run(["pdffonts", a.pdf], capture_output=True, text=True).stdout
+        out = subprocess.run(
+            ["pdffonts", a.pdf], capture_output=True, text=True, check=False
+        ).stdout
         lines = out.splitlines()
         if lines and "emb" in lines[0]:
             col = lines[0].index("emb")
@@ -213,7 +225,7 @@ def main():
                 )
 
     # ---- 7. podpis ----------------------------------------------------------
-    if not re.search(r"(Z powa[żz]aniem|podpis|_{5,}|…{3,})", t, re.I):
+    if not re.search(r"(Z powa[żz]aniem|podpis|_{5,}|…{3,})", t, re.IGNORECASE):
         o("W piśmie nie widać bloku podpisu — sprawdź, czy jest miejsce na podpis")
 
     # ---- raport -------------------------------------------------------------

--- a/scripts/manifest.py
+++ b/scripts/manifest.py
@@ -13,8 +13,14 @@ Znaczniki w index.md:
   <!-- KRUCZEK:MANIFEST:END -->
 """
 
-import sys, os, datetime, re, argparse
-from utils import sha256_file as sha256, human_size as human
+import argparse
+import datetime
+import os
+import re
+import sys
+
+from utils import human_size as human
+from utils import sha256_file as sha256
 
 SKIP_DIRS = {".git", "__pycache__", ".DS_Store", "node_modules", ".obsidian"}
 # index.md nie wchodzi do manifestu: manifest jest w nim zapisywany, więc jego suma
@@ -44,7 +50,11 @@ def rows(root):
         out.append(
             {
                 "rel": rel,
-                "mtime": datetime.date.fromtimestamp(st.st_mtime).isoformat(),
+                "mtime": datetime.datetime.fromtimestamp(
+                    st.st_mtime, tz=datetime.timezone.utc
+                )
+                .date()
+                .isoformat(),
                 "size": human(st.st_size),
                 "sha": sha256(p),
             }
@@ -59,7 +69,9 @@ def table(root):
         L.append(f"| `{r['rel']}` | {r['mtime']} | {r['size']} | `{r['sha']}` |")
     L.append("")
     L.append(
-        f"_Manifest wygenerowany {datetime.date.today().isoformat()} skryptem `manifest.py`. "
+        f"_Manifest wygenerowany "
+        f"{datetime.datetime.now(tz=datetime.timezone.utc).date().isoformat()} "
+        f"skryptem `manifest.py`. "
         f"Plików: {len(data)}. Pominięto `index.md` i `SHA256SUMS.txt` (pliki robocze teczki, "
         f"nie dowody). Opisy plików prowadź w tabeli powyżej manifestu._"
     )
@@ -80,7 +92,8 @@ def main():
         root = a.arg1
         lines = [f"{r['sha']}  {r['rel']}" for r in rows(root)]
         p = os.path.join(root, "SHA256SUMS.txt")
-        open(p, "w", encoding="utf-8").write("\n".join(lines) + "\n")
+        with open(p, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
         print(f"Zapisano {p} ({len(lines)} plików)")
 
     elif a.cmd == "sprawdz":
@@ -90,12 +103,13 @@ def main():
         p = os.path.join(root, "SHA256SUMS.txt")
         if os.path.exists(p):
             recorded = {}
-            for line in open(p, encoding="utf-8"):
-                line = line.rstrip("\n")
-                if not line.strip():
-                    continue
-                sha, rel = line.split(None, 1)
-                recorded[rel] = sha
+            with open(p, encoding="utf-8") as f:
+                for line in f:
+                    line = line.rstrip("\n")
+                    if not line.strip():
+                        continue
+                    sha, rel = line.split(None, 1)
+                    recorded[rel] = sha
             for rel, sha in recorded.items():
                 if rel not in actual:
                     print(f"BRAK PLIKU: {rel}")
@@ -115,7 +129,8 @@ def main():
             print(f"(brak {p} — pomijam porównanie z plikiem sum)")
         idx = os.path.join(root, "index.md")
         if os.path.exists(idx):
-            txt = open(idx, encoding="utf-8").read()
+            with open(idx, encoding="utf-8") as f:
+                txt = f.read()
             declared = set(re.findall(r"\b([0-9a-f]{64})\b", txt))
             real = set(actual.values())
             for d in sorted(declared - real):
@@ -138,18 +153,20 @@ def main():
         idx, root = a.arg1, a.arg2
         if not root:
             sys.exit("wstaw wymaga dwóch argumentów: <index.md> <katalog-sprawy>")
-        txt = open(idx, encoding="utf-8").read()
+        with open(idx, encoding="utf-8") as f:
+            txt = f.read()
         block = f"{START}\n{table(root)}\n{END}"
         if START in txt and END in txt:
             txt = re.sub(
                 re.escape(START) + r".*?" + re.escape(END),
                 lambda _: block,
                 txt,
-                flags=re.S,
+                flags=re.DOTALL,
             )
         else:
             txt = txt.rstrip() + "\n\n## Manifest plików\n\n" + block + "\n"
-        open(idx, "w", encoding="utf-8").write(txt)
+        with open(idx, "w", encoding="utf-8") as f:
+            f.write(txt)
         print(f"Zaktualizowano manifest w {idx}")
 
 

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -162,12 +162,13 @@ skip_sh() {
 
 skip_py() {
   case "$(basename "$1")" in
-    utils.py|kontrola_logika.py|test_kontrola_logika.py|run_tests.py) return 0 ;;  # moduły/testy — run_tests.py jest CLI, ale odpala go osobny krok CI
+    utils.py|kontrola_logika.py|run_tests.py) return 0 ;;  # moduły — run_tests.py jest CLI, ale odpala go osobny krok CI
     # Warstwy eml_forensics: importowane przez eml_forensics.py, nie CLI.
     # Wykluczenie było dopisane tylko w workflow (kontrola trybu pliku),
     # a smoketest.sh próbuje URUCHOMIĆ każdy skrypt bezpośrednio — więc
     # moduły bez +x wywracały build z „Permission denied”.
-    eml_forensics_logika.py|eml_forensics_raport.py|test_eml_forensics.py) return 0 ;;
+    eml_forensics_logika.py|eml_forensics_raport.py) return 0 ;;
+    test_*.py) return 0 ;;  # pliki testowe — źródło/import, nie CLI
     *) return 1 ;;
   esac
 }

--- a/scripts/test_kontrola_logika.py
+++ b/scripts/test_kontrola_logika.py
@@ -1,16 +1,16 @@
-#!/usr/bin/env python3
 """Unit testy logiki regex z kontrola_pisma.py. Tylko stdlib."""
 
 import unittest
+
 from kontrola_logika import (
-    find_placeholders,
-    find_attachment_page_headers,
     find_attachment_list_items,
+    find_attachment_page_headers,
     find_cross_references,
     find_numbering_gaps_and_duplicates,
-    titles_match,
     find_paragraph_numbering_issues,
+    find_placeholders,
     find_sha256_hashes,
+    titles_match,
 )
 
 SHA = "4f3548f05b0e47d9fa6ddd1e658fb7dee0c2a3c96a479f3c8770e18aeb8bb7e7"
@@ -223,7 +223,7 @@ class TestFindParagraphNumberingIssues(unittest.TestCase):
     def test_jeden_odstep_nie_liczy(self):
         # "2. tekst" (jeden spacja) nie jest ustępem wg formatu
         t = "1.  Pierwszy\n2. NieUstep\n3.  Trzeci"
-        dups, skoki = find_paragraph_numbering_issues(t)
+        _dups, skoki = find_paragraph_numbering_issues(t)
         self.assertIn((1, 3), skoki)
 
 

--- a/scripts/test_manifest.py
+++ b/scripts/test_manifest.py
@@ -1,0 +1,231 @@
+"""Unit testy manifest.py — sumy kontrolne i manifest plików sprawy.
+
+Bez zewnętrznych binarek (manifest.py operuje wyłącznie na systemie plików), więc
+w przeciwieństwie do kontrola_pisma.py czy build_pismo.py da się to przetestować
+wprost, bez mockowania subprocess.
+"""
+
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import manifest
+
+
+def uruchom(argv):
+    """Woła manifest.main() z podanym argv, zwraca (wyjście stdout, kod wyjścia)."""
+    old_argv = sys.argv
+    buf = io.StringIO()
+    try:
+        sys.argv = ["manifest.py", *argv]
+        with redirect_stdout(buf):
+            try:
+                manifest.main()
+                kod = 0
+            except SystemExit as e:
+                kod = e.code if isinstance(e.code, int) else (1 if e.code else 0)
+    finally:
+        sys.argv = old_argv
+    return buf.getvalue(), kod
+
+
+class TestWalk(unittest.TestCase):
+    def test_znajduje_pliki(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_text("a")
+            Path(tmp, "b.txt").write_text("b")
+            wynik = sorted(rel for _, rel in manifest.walk(tmp))
+            self.assertEqual(wynik, ["a.txt", "b.txt"])
+
+    def test_pomija_skip_dirs_i_ukryte_pliki(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, ".git"))
+            Path(tmp, ".git", "config").write_text("x")
+            Path(tmp, ".DS_Store").write_text("x")
+            Path(tmp, "widoczny.txt").write_text("x")
+            wynik = sorted(rel for _, rel in manifest.walk(tmp))
+            self.assertEqual(wynik, ["widoczny.txt"])
+
+    def test_pomija_pliki_manifestu(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "SHA256SUMS.txt").write_text("x")
+            Path(tmp, "index.md").write_text("x")
+            Path(tmp, "dowod.txt").write_text("x")
+            wynik = sorted(rel for _, rel in manifest.walk(tmp))
+            self.assertEqual(wynik, ["dowod.txt"])
+
+    def test_pomija_dowiazania_symboliczne(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "prawdziwy.txt").write_text("x")
+            os.symlink(
+                os.path.join(tmp, "prawdziwy.txt"), os.path.join(tmp, "link.txt")
+            )
+            wynik = sorted(rel for _, rel in manifest.walk(tmp))
+            self.assertEqual(wynik, ["prawdziwy.txt"])
+
+
+class TestRows(unittest.TestCase):
+    def test_zawiera_sha_rozmiar_i_date(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "plik.txt").write_bytes(b"tresc")
+            wynik = manifest.rows(tmp)
+            self.assertEqual(len(wynik), 1)
+            r = wynik[0]
+            self.assertEqual(r["rel"], "plik.txt")
+            self.assertEqual(r["size"], "5 B")
+            self.assertEqual(len(r["sha"]), 64)
+            self.assertRegex(r["mtime"], r"^\d{4}-\d{2}-\d{2}$")
+
+    def test_pusty_katalog(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(manifest.rows(tmp), [])
+
+
+class TestTable(unittest.TestCase):
+    def test_zawiera_naglowek_i_wiersz(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "plik.txt").write_bytes(b"x")
+            wynik = manifest.table(tmp)
+            self.assertIn("| Plik | Data pliku | Rozmiar | SHA-256 |", wynik)
+            self.assertIn("`plik.txt`", wynik)
+            self.assertIn("Plików: 1.", wynik)
+
+    def test_pusty_katalog_zero_plikow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIn("Plików: 0.", manifest.table(tmp))
+
+
+class TestMainSkan(unittest.TestCase):
+    def test_wypisuje_tabele(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_text("a")
+            out, kod = uruchom(["skan", tmp])
+            self.assertEqual(kod, 0)
+            self.assertIn("a.txt", out)
+
+
+class TestMainSumy(unittest.TestCase):
+    def test_zapisuje_sha256sums(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_bytes(b"a")
+            out, kod = uruchom(["sumy", tmp])
+            self.assertEqual(kod, 0)
+            self.assertIn("Zapisano", out)
+            p = Path(tmp, "SHA256SUMS.txt")
+            self.assertTrue(p.exists())
+            self.assertIn("a.txt", p.read_text())
+
+
+class TestMainSprawdz(unittest.TestCase):
+    def test_ok_gdy_zgodne(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_bytes(b"a")
+            uruchom(["sumy", tmp])
+            out, kod = uruchom(["sprawdz", tmp])
+            self.assertEqual(kod, 0)
+            self.assertIn("OK", out)
+
+    def test_wykrywa_brakujacy_plik(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_bytes(b"a")
+            uruchom(["sumy", tmp])
+            os.remove(os.path.join(tmp, "a.txt"))
+            out, kod = uruchom(["sprawdz", tmp])
+            self.assertEqual(kod, 1)
+            self.assertIn("BRAK PLIKU: a.txt", out)
+
+    def test_wykrywa_niezgodna_sume(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_bytes(b"a")
+            uruchom(["sumy", tmp])
+            Path(tmp, "a.txt").write_bytes(b"zmienione")
+            out, kod = uruchom(["sprawdz", tmp])
+            self.assertEqual(kod, 1)
+            self.assertIn("NIEZGODNA SUMA: a.txt", out)
+
+    def test_wykrywa_nowy_plik(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_bytes(b"a")
+            uruchom(["sumy", tmp])
+            Path(tmp, "b.txt").write_bytes(b"b")
+            out, kod = uruchom(["sprawdz", tmp])
+            self.assertEqual(kod, 0)
+            self.assertIn("NOWY PLIK", out)
+            self.assertIn("b.txt", out)
+
+    def test_ignoruje_puste_linie_w_sha256sums(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_bytes(b"a")
+            sha = manifest.rows(tmp)[0]["sha"]
+            Path(tmp, "SHA256SUMS.txt").write_text(f"\n{sha}  a.txt\n\n")
+            out, kod = uruchom(["sprawdz", tmp])
+            self.assertEqual(kod, 0)
+            self.assertIn("OK", out)
+
+    def test_bez_sha256sums_pomija_porownanie(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_bytes(b"a")
+            out, kod = uruchom(["sprawdz", tmp])
+            self.assertEqual(kod, 0)
+            self.assertIn("pomijam porównanie", out)
+
+    def test_index_md_z_odnaleziona_suma(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_bytes(b"a")
+            wynik = manifest.rows(tmp)
+            sha = wynik[0]["sha"]
+            Path(tmp, "index.md").write_text(f"Suma: {sha}\n")
+            out, kod = uruchom(["sprawdz", tmp])
+            self.assertEqual(kod, 0)
+            self.assertIn("index.md: 1 sum, wszystkie odnalezione: True", out)
+
+    def test_index_md_z_suma_bez_pliku(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_bytes(b"a")
+            obca_suma = "a" * 64
+            Path(tmp, "index.md").write_text(f"Suma: {obca_suma}\n")
+            out, kod = uruchom(["sprawdz", tmp])
+            self.assertEqual(kod, 1)
+            self.assertIn("SUMA W index.md BEZ ODPOWIADAJĄCEGO PLIKU", out)
+
+
+class TestMainWstaw(unittest.TestCase):
+    def test_wymaga_dwoch_argumentow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            idx = os.path.join(tmp, "index.md")
+            Path(idx).write_text("treść")
+            _out, kod = uruchom(["wstaw", idx])
+            self.assertNotEqual(kod, 0)
+
+    def test_dopisuje_blok_gdy_brak_znacznikow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_bytes(b"a")
+            idx = os.path.join(tmp, "index.md")
+            Path(idx).write_text("# Sprawa\n\ntreść wstępu\n")
+            _out, kod = uruchom(["wstaw", idx, tmp])
+            self.assertEqual(kod, 0)
+            txt = Path(idx).read_text()
+            self.assertIn(manifest.START, txt)
+            self.assertIn(manifest.END, txt)
+            self.assertIn("a.txt", txt)
+            self.assertIn("treść wstępu", txt)
+
+    def test_podmienia_istniejacy_blok(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_bytes(b"a")
+            idx = os.path.join(tmp, "index.md")
+            stary_blok = f"{manifest.START}\nSTARA TREŚĆ\n{manifest.END}"
+            Path(idx).write_text(f"# Sprawa\n\n{stary_blok}\n")
+            _out, kod = uruchom(["wstaw", idx, tmp])
+            self.assertEqual(kod, 0)
+            txt = Path(idx).read_text()
+            self.assertNotIn("STARA TREŚĆ", txt)
+            self.assertIn("a.txt", txt)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """utils.py — wspólne narzędzia dla skryptów kruczka."""
 
 import hashlib


### PR DESCRIPTION
## Summary
- Naprawia 36 błędów `ruff check` w `scripts/` (import order, context managery na `open()`, `subprocess.run(..., check=)`, `re.I`→`re.IGNORECASE`, nieużywane zmienne, shebangi w modułach bez +x, naiwne `datetime.date`).
- Dokłada doctesty dla dwóch dotąd nietkniętych czystych funkcji w `eml_forensics_logika.py` (`_match_declarations`, `_rules_in`).
- Dokłada `scripts/test_manifest.py` (20 testów jednostkowych, bez mockowania — `manifest.py` operuje wyłącznie na systemie plików). Pokrycie `manifest.py`: 11% → 100%; całości repo: 85% → 88%.
- Aktualizuje wykluczenia bitu +x w `smoketest.sh` i workflow o `test_*.py`, żeby nowy plik testowy nie wywracał kontroli trybu pliku.

## Test plan
- [x] `ruff check .` — czysto
- [x] `ruff format --check .` — czysto
- [x] `python3 scripts/run_tests.py` — 401 testów, OK
- [x] `python3 -m coverage run scripts/run_tests.py && coverage report` — 88% (z 85%)
- [x] `bash scripts/smoketest.sh scripts` — OK (lokalnie, macOS)